### PR TITLE
add dedupe check on peers

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -240,6 +240,9 @@ module.exports = function (app) {
         };
 
         this.process = function (p, next) {
+            if (-1 !== this.ips.indexOf(p.ip))
+                return next();
+
             p.osBrand = osBrand(p.os);
             this.ips.push(p.ip);
 


### PR DESCRIPTION
The peers API "/api/peers" is often sending the same peer multiple times which is breaking the network monitoring https://explorer.lisk.io/networkMonitor
Just stay on the page for a while and you will see the number of connected peers changing constantly.

This bug might need code change on the main LISK repo, however I think it doesn't hurt to do a simple de-duplicate on the explorer side