### PR TITLE
Resolve crash from publickey searches

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -326,7 +326,7 @@ module.exports = function (app) {
                 url : app.get('lisk address') + '/api/delegates/search?q=' + params + '&limit=1',
                 json : true
             }, function (err, response, body) {
-            if (err || response.statusCode !== 200 || !body.delegates[0]) {
+            if (err || response.statusCode !== 200 || !body.delegates) {
                 return error({ success : false, error : err });
             } else {
                 body.delegates = _.isArray(body.delegates) ? body.delegates : [];


### PR DESCRIPTION
When the array returns as undefined it crashes the node, this will just check if the contents are not null as intended.