### PR TITLE
Improvment pack

### DIFF
--- a/api/delegates.js
+++ b/api/delegates.js
@@ -64,4 +64,11 @@ module.exports = function (app) {
             function (data) { req.json = data; return next(); }
         );
     });
+
+    app.get('/api/delegates/getDelegateProposals', function (req, res, next) {
+        api.getDelegateProposals(
+            function (data) { res.json(data); },
+            function (data) { req.json = data; return next(); }
+        );
+    });
 };

--- a/app.js
+++ b/app.js
@@ -26,6 +26,15 @@ app.set('exchange enabled', config.enableExchange);
 app.set('candles enabled', config.enableCandles);
 app.set('orders enabled', config.enableOrders);
 
+app.use (function (req, res, next) {
+    res.setHeader ('X-Frame-Options', 'DENY');
+    res.setHeader ('X-Content-Type-Options', 'nosniff');
+    res.setHeader ('X-XSS-Protection', '1; mode=block')
+    var ws_src = (req.protocol === 'http' ? 'ws://' : 'wss://') + req.get('host');
+    res.setHeader ('Content-Security-Policy', "frame-ancestors 'none'; default-src 'self'; connect-src 'self' " + ws_src + "; img-src 'self' https://*.tile.openstreetmap.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com");
+    return next();
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.locals.redis = client;

--- a/app.js
+++ b/app.js
@@ -29,9 +29,9 @@ app.set('orders enabled', config.enableOrders);
 app.use (function (req, res, next) {
     res.setHeader ('X-Frame-Options', 'DENY');
     res.setHeader ('X-Content-Type-Options', 'nosniff');
-    res.setHeader ('X-XSS-Protection', '1; mode=block')
+    res.setHeader ('X-XSS-Protection', '1; mode=block');
     var ws_src = (req.protocol === 'http' ? 'ws://' : 'wss://') + req.get('host');
-    res.setHeader ('Content-Security-Policy', "frame-ancestors 'none'; default-src 'self'; connect-src 'self' " + ws_src + "; img-src 'self' https://*.tile.openstreetmap.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com");
+    res.setHeader ('Content-Security-Policy', 'frame-ancestors \'none\'; default-src \'self\'; connect-src \'self\' ' + ws_src + '; img-src \'self\' https://*.tile.openstreetmap.org; style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com; font-src \'self\' https://fonts.gstatic.com');
     return next();
 });
 

--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -292,7 +292,7 @@ module.exports = function (app) {
                     }
                 }
             );
-    }
+    };
 
     function LastBlock () {
         this.getBlock = function (cb) {

--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -252,7 +252,7 @@ module.exports = function (app) {
                 nextPage = false,
                 url = 'https://forum.lisk.io/viewforum.php?f=48&start=',
                 nextPageRegex = /<li class="next"><a href.+? rel="next" role="button">/m,
-                proposalMatch = /<a href="\.\/viewtopic\.php\?f=48&amp;t=(\d+)&amp;sid=.+?" class="topictitle">(.+?)\s+(?:[-–](?:\s*rank)?\s*#\s*\d+\s*)?.*?[-–]\s+(.+?)<\/a>/mgi,
+                proposalRegex = /<a href="\.\/viewtopic\.php\?f=48&amp;t=(\d+)&amp;sid=.+?" class="topictitle">(.+?)\s+(?:[-–](?:\s*rank)?\s*#\s*\d+\s*)?.*?[-–]\s+(.+?)<\/a>/mgi,
                 result = [];
 
             async.doUntil(
@@ -269,9 +269,9 @@ module.exports = function (app) {
                         // Parse delegate proposal topics titles
                         var m;
                         do {
-                            m = proposalMatch.exec(body);
+                            m = proposalRegex.exec(body);
                             if (m) {
-                                result.push ({topic: m[1], name: m[2].toLowerCase(), description: m[3]});
+                                result.push ({topic: m[1], name: m[2].toLowerCase(), description: _.unescape (m[3])});
                             }
                         } while (m);
 

--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -246,6 +246,54 @@ module.exports = function (app) {
         });
     };
 
+    this.getDelegateProposals = function (error, success) {
+            var offset = 0,
+                limit  = 25,
+                nextPage = false,
+                url = 'https://forum.lisk.io/viewforum.php?f=48&start=',
+                nextPageRegex = /<li class="next"><a href.+? rel="next" role="button">/m,
+                proposalMatch = /<a href="\.\/viewtopic\.php\?f=48&amp;t=(\d+)&amp;sid=.+?" class="topictitle">(.+?)\s+(?:[-–](?:\s*rank)?\s*#\s*\d+\s*)?.*?[-–]\s+(.+?)<\/a>/mgi,
+                result = [];
+
+            async.doUntil(
+                function (next) {
+                    console.log ('Parsing delegate proposals: ' + url + offset);
+                    request.get({
+                        url: url + offset,
+                        json : false
+                    }, function (err, resp, body) {
+                        if (err || resp.statusCode !== 200) {
+                            return next(err || 'Response was unsuccessful');
+                        }
+
+                        // Parse delegate proposal topics titles
+                        var m;
+                        do {
+                            m = proposalMatch.exec(body);
+                            if (m) {
+                                result.push ({topic: m[1], name: m[2].toLowerCase(), description: m[3]});
+                            }
+                        } while (m);
+
+                        // Continue if there is next page
+                        nextPage = nextPageRegex.exec (body);
+                        return next();
+                    });
+                },
+                function () {
+                    offset += limit;
+                    return !nextPage;
+                },
+                function (err) {
+                    if (err) {
+                        error ({ success: false, error: err || 'Unable to parse delegate proposals' });
+                    } else {
+                        success ({ success: true, proposals: result, count: result.length });
+                    }
+                }
+            );
+    }
+
     function LastBlock () {
         this.getBlock = function (cb) {
             request.get({

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -332,6 +332,7 @@ module.exports = function (app) {
 
     var getSenderDelegate = function (transaction, cb, tmpDelegateCache) {
         if (!transaction.senderPublicKey) {
+            transaction.senderDelegate = null;
             return cb (null, transaction);
         }
 
@@ -360,6 +361,7 @@ module.exports = function (app) {
 
     var getRecipientPublicKey = function (transaction, cb, tmpDelegateCache) {
         if (!transaction.recipientId || transaction.type !== 0) {
+            transaction.recipientPublicKey = null;
             return cb (null, transaction);
         }
 
@@ -386,6 +388,7 @@ module.exports = function (app) {
 
     var getRecipientDelegate = function (transaction, cb, tmpDelegateCache) {
         if (!transaction.recipientPublicKey) {
+            transaction.recipientDelegate = null;
             return cb (null, transaction);
         }
 

--- a/public/src/css/common.css
+++ b/public/src/css/common.css
@@ -258,7 +258,7 @@ a:hover {
 }
 
 .navbar-form {
-  margin-top: 20px;
+  margin-top: 23px;
 }
 
 @media (max-width: 1200px) {
@@ -302,24 +302,18 @@ a:hover {
 
 .navbar-default .navbar-brand {
   color: white;
-  padding: 10px;
+  padding: 13px;
   height: 76px;
 }
 
 .navbar-brand .logo {
-  background-image: url(/img/logo.png);
   height: 55px;
   width: 100px;
 }
 
-@media only screen and (-Webkit-min-device-pixel-ratio: 1.5),
-       only screen and (-moz-min-device-pixel-ratio: 1.5),
-       only screen and (-o-min-device-pixel-ratio: 3/2),
-       only screen and (min-device-pixel-ratio: 1.5) {
-  .navbar-brand .logo {
-    background-image: url(/img/logo2x.png);
-    background-size: 100%;
-  }
+.navbar-brand .logo img {
+  height: 100%;
+  width: 100%;
 }
 
 .navbar-form .form-control {
@@ -387,10 +381,9 @@ a:hover {
   background-color: #655740;
   border-radius: 3px;
   margin-left: 10px;
-  margin-top: 10px;
+  margin-top: 12px;
   min-width: 389.375px;
   min-height: 29px;
-  padding: 2px 0px;
   font-size: 12px;
   color: #eee;
   text-align: center;
@@ -1046,4 +1039,8 @@ a.sort-order span.reverse:after {
     font-weight: 300;
     line-height: 1.2;
     margin-bottom: 20px;
+}
+.proposal-icon {
+    vertical-align: middle;
+    margin-top: -5px;
 }

--- a/public/src/css/common.css
+++ b/public/src/css/common.css
@@ -38,10 +38,12 @@ h1>small {
 
 a, a:visited, a:focus {
   color: #0288d1;
+  text-decoration: none;
 }
 
 a:hover {
   color: #f57c00;
+  text-decoration: none;
 }
 
 /* Bootstrap fix for ui.bootstrap */

--- a/public/src/js/controllers/delegateMonitor.js
+++ b/public/src/js/controllers/delegateMonitor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('lisk_explorer.tools').controller('DelegateMonitor',
-  function (delegateMonitor, orderBy, $scope, $http) {
+  function (delegateMonitor, orderBy, $scope, $rootScope, $http) {
       delegateMonitor($scope);
 
       $scope.getStandby = function (n) {
@@ -15,6 +15,12 @@ angular.module('lisk_explorer.tools').controller('DelegateMonitor',
 
           $http.get('/api/delegates/getStandby?n=' + offset).then(function (resp) {
               if (resp.data.success) {
+                  _.each(resp.data.delegates, function (d) {
+                      d.proposal = _.find ($rootScope.delegateProposals, function (p) {
+                        return p.name === d.username.toLowerCase ();
+                      });
+                  });
+
                   $scope.standbyDelegates = resp.data.delegates;
               }
               if (resp.data.pagination) {

--- a/public/src/js/filters.js
+++ b/public/src/js/filters.js
@@ -160,4 +160,15 @@ angular.module('lisk_explorer')
       return function (a) {
           return (a.username || (a.knowledge && a.knowledge.owner) || a.address);
       };
+  }).filter('proposal', function ($sce) {
+      return function (name, proposals) {
+          var p = _.find (proposals, function (p) {
+              return p.name === name.toLowerCase ();
+          });
+          if (p) {
+              return $sce.trustAsHtml('<a class="glyphicon glyphicon-user" href="https://forum.lisk.io/viewtopic.php?f=48&t=' + p.topic + '" title="' + _.escape (p.description) + '" target="_blank"></a> ' + name);
+          } else {
+              return $sce.trustAsHtml(name);
+          }
+      };
   });

--- a/public/src/js/services/delegateMonitor.js
+++ b/public/src/js/services/delegateMonitor.js
@@ -1,11 +1,15 @@
 'use strict';
 
-var DelegateMonitor = function ($scope, forgingMonitor) {
+var DelegateMonitor = function ($scope, $rootScope, forgingMonitor) {
     this.updateActive = function (active) {
         _.each(active.delegates, function (d) {
             d.forgingStatus = forgingMonitor.getStatus(d);
+            d.proposal = _.find ($rootScope.delegateProposals, function (p) {
+              return p.name === d.username.toLowerCase ();
+            });
         });
         $scope.activeDelegates = active.delegates;
+
         updateForgingTotals(active.delegates);
         updateForgingProgress($scope.forgingTotals);
     };
@@ -104,9 +108,9 @@ var DelegateMonitor = function ($scope, forgingMonitor) {
 };
 
 angular.module('lisk_explorer.tools').factory('delegateMonitor',
-  function ($socket, forgingMonitor) {
+  function ($socket, $rootScope, forgingMonitor) {
       return function ($scope) {
-          var delegateMonitor = new DelegateMonitor($scope, forgingMonitor),
+          var delegateMonitor = new DelegateMonitor($scope, $rootScope, forgingMonitor),
               ns = $socket('/delegateMonitor');
 
           ns.on('data', function (res) {

--- a/public/src/js/services/header.js
+++ b/public/src/js/services/header.js
@@ -23,6 +23,14 @@ var Header = function ($rootScope) {
             $rootScope.btc_usd = $rootScope.lisk_btc = $rootScope.lisk_usd = 0.0;
         }
     };
+
+    this.updateDelegateProposals = function (res) {
+        if (res.success) {
+            $rootScope.delegateProposals = res.proposals;
+        } else {
+            $rootScope.delegateProposals = [];
+        }
+    };
 };
 
 angular.module('lisk_explorer.system').factory('header',
@@ -35,6 +43,11 @@ angular.module('lisk_explorer.system').factory('header',
               if (res.status) { header.updateBlockStatus(res.status); }
               if (res.ticker) { header.updatePriceTicker(res.ticker); }
           });
+
+          ns.on('delegateProposals', function (res) {
+              if (res) { header.updateDelegateProposals(res); }
+          });
+
 
           $scope.$on('$destroy', function (event) {
               ns.removeAllListeners();

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -72,7 +72,7 @@
               <tbody>
                 <tr>
                   <td><strong>Name</strong></td>
-                  <td class="ellipsis text-right">{{address.delegate.username}}</td>
+                  <td class="ellipsis text-right" ng-bind-html="address.delegate.username | proposal:delegateProposals"></td>
                 </tr>
                 <tr>
                   <td><strong>Uptime</strong></td>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -22,9 +22,16 @@
   </div>
   <div data-ng-if="address.balance >= 0">
     <div class="well well-sm ellipsis">
-      <strong>Address</strong>
-      <span class="text-muted">{{address.address}}</span>
-      <span class="btn-copy" clip-copy="address.address"></span>
+      <div class="pull-left">
+        <strong>Address</strong>
+        <span class="text-muted">{{address.address}}</span>
+        <span class="btn-copy" clip-copy="address.address"></span>
+      </div>
+      <div class="pull-right hidden-xs hidden-sm">
+        <strong>Public key</strong>
+        <span class="text-muted">{{address.publicKey}}</span>
+        <span class="btn-copy" clip-copy="address.publicKey"></span>
+      </div>
     </div>
     <h2>Summary <small>confirmed</small></h2>
     <div class="row">

--- a/public/views/delegateMonitor.html
+++ b/public/views/delegateMonitor.html
@@ -29,11 +29,11 @@
               <div class="pull-left last-block">
                 <p class="small-title">Last Block By</span>
                 <p class="big-details" data-ng-switch="!!lastBlock">
-                  <a data-ng-href="/address/{{lastBlock.delegate.address}}" data-ng-switch-when="true" target="_new">{{lastBlock.delegate.username}}</a>
+                  <a data-ng-href="/address/{{lastBlock.delegate.address}}" data-ng-switch-when="true">{{lastBlock.delegate.username}}</a>
                   <span class="text-muted" data-ng-switch-when="false">N/A</span>
                 </p>
                 <p class="text-muted" data-ng-switch="!!lastBlock">
-                  <a data-ng-href="/block/{{lastBlock.id}}" data-ng-switch-when="true" target="_new">{{lastBlock.id}}</a>
+                  <a data-ng-href="/block/{{lastBlock.id}}" data-ng-switch-when="true">{{lastBlock.id}}</a>
                   <span class="text-muted" data-ng-switch-when="false">N/A</span>
                 </p>
                 <p class="text-muted">
@@ -56,15 +56,15 @@
                   <span data-ng-repeat='v in nextForgers track by $index'>
                   <div data-ng-if="$first">
                     <p class="big-details">
-                      <a data-ng-href="/address/{{v.address}}" target="_new">{{v.username}}</a>
+                      <a data-ng-href="/address/{{v.address}}">{{v.username}}</a>
                     </p>
                   </div>
                   <span data-ng-if="!$first && !$last">
-                    <a data-ng-href="/address/{{v.address}}" target="_new">{{v.username}}</a>
+                    <a data-ng-href="/address/{{v.address}}">{{v.username}}</a>
                     <span class="text-muted">&bull;</span>
                   </span>
                   <span data-ng-if="$last">
-                    <a data-ng-href="/address/{{v.address}}" target="_new">{{v.username}}</a>
+                    <a data-ng-href="/address/{{v.address}}">{{v.username}}</a>
                   </span>
                   </span>
                 </div>
@@ -97,7 +97,7 @@
               <div class="pull-left best-forger">
                 <p class="small-title">Best Forger</p>
                 <p class="big-details" data-ng-switch="!!bestForger">
-                  <a data-ng-href="/address/{{bestForger.address}}" data-ng-switch-when="true" target="_new">{{bestForger.username}}</a>
+                  <a data-ng-href="/address/{{bestForger.address}}" data-ng-switch-when="true">{{bestForger.username}}</a>
                   <span class="text-muted" data-ng-switch-when="false">N/A</span>
                 </p>
                 <p class="text-muted lisk">{{bestForger.forged || 0 | lisk}} LSK forged</p>
@@ -114,7 +114,7 @@
                 <p class="big-details">{{bestProductivity.productivity || 0}}%</p>
                 <p data-ng-switch="!!bestProductivity">
                   <span class="text-muted">by</span>
-                  <a data-ng-href="/address/{{bestProductivity.address}}" data-ng-switch-when="true" target="_new">{{bestProductivity.username}}</a>
+                  <a data-ng-href="/address/{{bestProductivity.address}}" data-ng-switch-when="true">{{bestProductivity.username}}</a>
                   <span class="text-muted" data-ng-switch-when="false">N/A</span>
                 </p>
               </div>
@@ -290,7 +290,7 @@
               <tbody>
                 <tr data-ng-repeat="d in activeDelegates | orderBy:natural(tables.active.predicate):tables.active.reverse track by d.rate">
                   <td>{{d.rate}}</td>
-                  <td><a data-ng-href="/address/{{d.address}}" target="_new">{{d.username}}</a></td>
+                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}" target="_new">{{d.username}}</a></td>
                   <td class="hidden-xs"><span class="text-muted">{{d.address}}</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forged | lisk}} <span class="text-muted">LSK</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forgingTime | forgingTime}}</td>
@@ -324,7 +324,7 @@
               <tbody>
                 <tr data-ng-repeat='d in standbyDelegates | orderBy:natural(tables.standby.predicate):tables.standby.reverse track by d.rate'>
                   <td>{{d.rate}}</td>
-                  <td><a data-ng-href="/address/{{d.address}}" target="_new">{{d.username}}</a></td>
+                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
                   <td class="hidden-xs"><span class="text-muted">{{d.address}}</span></td>
                   <td class="hidden-xs">{{d.productivity || 0}}%</td>
                   <td class="hidden-xs">{{d.approval}}%</td>

--- a/public/views/delegateMonitor.html
+++ b/public/views/delegateMonitor.html
@@ -129,7 +129,7 @@
                 <p class="big-details">{{worstProductivity.productivity || 0}}%</p>
                 <p data-ng-switch="!!worstProductivity">
                   <span class="text-muted">by</span>
-                  <a data-ng-href="/address/{{worstProductivity.address}}" data-ng-switch-when="true" target="_new">{{worstProductivity.username}}</a>
+                  <a data-ng-href="/address/{{worstProductivity.address}}" data-ng-switch-when="true">{{worstProductivity.username}}</a>
                   <span class="text-muted" data-ng-switch-when="false">N/A</span>
                 </p>
               </div>
@@ -165,10 +165,10 @@
                     <tbody>
                       <tr data-ng-repeat='v in votes track by $index'>
                         <td class="voter">
-                          <a data-ng-href="/address/{{v.senderId}}" target="_new">{{v.delegate.username || v.senderId}}</a>
+                          <a data-ng-href="/address/{{v.senderId}}">{{v.delegate.username || v.senderId}}</a>
                         </td>
                         <td class="tx hidden-xs">
-                          <a class="ellipsis" data-ng-href="/tx/{{v.id}}" target="_new">{{v.id}}</a>
+                          <a class="ellipsis" data-ng-href="/tx/{{v.id}}">{{v.id}}</a>
                         </td>
                         <td class="time-ago">
                           <span class="text-muted">{{v.timestamp | timeAgo}}</span>
@@ -204,10 +204,10 @@
                     <tbody>
                       <tr data-ng-repeat='r in registrations track by $index'>
                         <td class="delegate">
-                          <a data-ng-href="/address/{{r.senderId}}" target="_new">{{r.delegate.username}}</a>
+                          <a data-ng-href="/address/{{r.senderId}}">{{r.delegate.username}}</a>
                         </td>
                         <td class="tx hidden-xs">
-                          <a class="ellipsis" data-ng-href="/tx/{{r.id}}" target="_new">{{r.id}}</a>
+                          <a class="ellipsis" data-ng-href="/tx/{{r.id}}">{{r.id}}</a>
                         </td>
                         <td class="time-ago">
                           <span class="text-muted">{{r.timestamp | timeAgo}}</span>
@@ -290,7 +290,7 @@
               <tbody>
                 <tr data-ng-repeat="d in activeDelegates | orderBy:natural(tables.active.predicate):tables.active.reverse track by d.rate">
                   <td>{{d.rate}}</td>
-                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}" target="_new">{{d.username}}</a></td>
+                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
                   <td class="hidden-xs"><span class="text-muted">{{d.address}}</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forged | lisk}} <span class="text-muted">LSK</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forgingTime | forgingTime}}</td>

--- a/public/views/delegateMonitor.html
+++ b/public/views/delegateMonitor.html
@@ -290,7 +290,7 @@
               <tbody>
                 <tr data-ng-repeat="d in activeDelegates | orderBy:natural(tables.active.predicate):tables.active.reverse track by d.rate">
                   <td>{{d.rate}}</td>
-                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
+                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user proposal-icon" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
                   <td class="hidden-xs"><span class="text-muted">{{d.address}}</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forged | lisk}} <span class="text-muted">LSK</span></td>
                   <td class="hidden-xs hidden-sm">{{d.forgingTime | forgingTime}}</td>
@@ -324,7 +324,7 @@
               <tbody>
                 <tr data-ng-repeat='d in standbyDelegates | orderBy:natural(tables.standby.predicate):tables.standby.reverse track by d.rate'>
                   <td>{{d.rate}}</td>
-                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
+                  <td><a data-ng-if="d.proposal" class="glyphicon glyphicon-user proposal-icon" data-ng-href="https://forum.lisk.io/viewtopic.php?f=48&t={{d.proposal.topic}}" title="{{d.proposal.description}}" target="_new"></a> <a data-ng-href="/address/{{d.address}}">{{d.username}}</a></td>
                   <td class="hidden-xs"><span class="text-muted">{{d.address}}</span></td>
                   <td class="hidden-xs">{{d.productivity || 0}}%</td>
                   <td class="hidden-xs">{{d.approval}}%</td>

--- a/public/views/index/header.html
+++ b/public/views/index/header.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/"><div class="logo" title="Lisk"></div></a>
+      <a class="navbar-brand" href="/"><div class="logo" title="Lisk"><img src="/img/logo.png"></div></a>
     </div>
     <div class="collapse navbar-collapse" collapse="$root.isCollapsed">
       <form id="search-form" data-ng-controller="SearchController" class="navbar-form navbar-left hidden-xs" role="search" data-ng-submit="search()">

--- a/public/views/networkMonitor.html
+++ b/public/views/networkMonitor.html
@@ -38,7 +38,7 @@
                 </div>
                 <div data-ng-if="lastBlock">
                   <p class="big-details">
-                    <a data-ng-href="/block/{{lastBlock.id}}" target="_new">{{lastBlock.id}}</a>
+                    <a data-ng-href="/block/{{lastBlock.id}}">{{lastBlock.id}}</a>
                   </p>
                   <p class="text-muted">
                     <span class="lisk">{{lastBlock.totalAmount + lastBlock.totalFee || 0 | lisk}} LSK</span>
@@ -64,7 +64,7 @@
                 </div>
                 <div data-ng-if="bestBlock">
                   <p class="big-details">
-                    <a data-ng-href="/block/{{bestBlock.id}}" target="_new">{{bestBlock.id}}</a>
+                    <a data-ng-href="/block/{{bestBlock.id}}">{{bestBlock.id}}</a>
                   </p>
                   <p class="text-muted">
                     <span class="lisk">{{bestBlock.totalAmount + bestBlock.totalFee || 0 | lisk}} LSK</span>

--- a/sockets/header.js
+++ b/sockets/header.js
@@ -6,16 +6,21 @@ var api = require('../lib/api'),
 module.exports = function (app, connectionHandler, socket) {
     var blocks     = new api.blocks(app),
         common     = new api.common(app),
+        delegates  = new api.delegates(app),
         connection = new connectionHandler('Header:', socket, this),
-        interval   = null,
-        data       = {};
+        intervals  = [],
+        data       = {},
+        tmpData    = {};
 
     var running = {
-        'getBlockStatus' : false,
-        'getPriceTicker' : false
+        'getBlockStatus'       : false,
+        'getPriceTicker'       : false,
+        'getDelegateProposals' : false
     };
 
     this.onInit = function () {
+        this.onConnect(); // Prevents data wipe
+
         async.parallel([
             getBlockStatus,
             getPriceTicker
@@ -30,28 +35,43 @@ module.exports = function (app, connectionHandler, socket) {
                 log('Emitting new data');
                 socket.emit('data', data);
 
-                if (interval == null) {
-                    interval = setInterval(emitData, 10000);
-                }
+                newInterval(0, 10000, emitData);
+                // Update and emit delegate proposals every 10 minutes
+                newInterval(1, 600000, emitDelegateProposals);
             }
         }.bind(this));
+
+        emitDelegateProposals ();
     };
 
     this.onConnect = function () {
+        log ('Emitting existing delegate proposals');
+        socket.emit ('delegateProposals', tmpData.proposals);
+
         log('Emitting existing data');
         socket.emit('data', data);
     };
 
     this.onDisconnect = function () {
-        clearInterval(interval);
-        interval = null;
-        data     = {};
+        for (var i = 0; i < intervals.length; i++) {
+            clearInterval(intervals[i]);
+        }
+        intervals = [];
     };
 
     // Private
 
     var log = function (msg) {
         console.log('Header:', msg);
+    };
+
+    var newInterval = function (i, delay, cb) {
+        if (intervals[i] !== undefined) {
+            return null;
+        } else {
+            intervals[i] = setInterval(cb, delay);
+            return intervals[i];
+        }
     };
 
     var getBlockStatus = function (cb) {
@@ -76,6 +96,17 @@ module.exports = function (app, connectionHandler, socket) {
         );
     };
 
+    var getDelegateProposals = function (cb) {
+        if (running.getDelegateProposals) {
+            return cb ('getDelegateProposals (already running)');
+        }
+        running.getDelegateProposals = true;
+        return delegates.getDelegateProposals (
+            function (res) { running.getDelegateProposals = false; cb ('DelegateProposals'); },
+            function (res) { running.getDelegateProposals = false; cb (null, res); }
+        );
+    };
+
     var emitData = function () {
         var thisData = {};
 
@@ -95,5 +126,21 @@ module.exports = function (app, connectionHandler, socket) {
                 socket.emit('data', thisData);
             }
         }.bind(this));
+    };
+
+    var emitDelegateProposals = function () {
+        async.parallel ([
+            getDelegateProposals
+        ],
+        function (err, res) {
+            if (err) {
+                log ('Error retrieving: ' + err);
+            } else {
+                tmpData.proposals = res[0];
+            }
+
+            log ('Emitting updated delegate proposals');
+            socket.emit ('delegateProposals', tmpData.proposals);
+        });
     };
 };


### PR DESCRIPTION
Added links to delegate proposals in delegate monitor (closes https://github.com/LiskHQ/lisk-explorer/issues/36):
- added `/api/delegates/getDelegateProposals` endpoint
- added links to delegate proposals in delegate monitor (for active and
standby delegates)
- added link to delegate proposal on address page

Other changes:
- removed bad-looking underline decoration on links (hover, focus)
- removed target="_new" in various places
- dispaly public key on address page (closes https://github.com/LiskHQ/lisk-explorer/issues/26)
- added security headers: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Content-Security-Policy (closes https://github.com/LiskHQ/lisk-explorer/issues/13, closes https://github.com/LiskHQ/lisk-explorer/issues/15)
