### PR TITLE
12 Character+ balance pushes Navigation box and LSK off page on mobile

### DIFF
--- a/public/views/address.html
+++ b/public/views/address.html
@@ -16,7 +16,8 @@
       </a>
     </div>
   </div>
-  <h1>Address<small data-ng-if="address.balance >= 0">&nbsp;{{address.balance | currency:currency}} {{currency.symbol}}</small></h1>
+  <h1>Address</h1>
+  <h2>Balance<small data-ng-if="address.balance >= 0">&nbsp;{{address.balance | lisk}} LSK</small></h2>
   <div class="text-muted" data-ng-if="!(address.balance >= 0)">
     <span>Loading Address <i class="fa fa-spinner fa-spin"></i></span>
   </div>


### PR DESCRIPTION
**12 Character+ addresses push the navigation off the page on mobile and altogether looks bad. Also Address with the balance next to it is quite confusing. **
![offpagemobilenav](https://cloud.githubusercontent.com/assets/7875147/21871963/364fb70e-d82b-11e6-80f2-1acc1327be28.png)





