### PR TITLE
Address Summary changes + retain mobile pubkey support.

### DIFF
--- a/public/views/address.html
+++ b/public/views/address.html
@@ -20,27 +20,7 @@
   <div class="text-muted" data-ng-if="!(address.balance >= 0)">
     <span>Loading Address <i class="fa fa-spinner fa-spin"></i></span>
   </div>
-  <div data-ng-if="address.balance >= 0">
-    <div class="well well-sm ellipsis">
-      <div class="pull-left">
-        <strong>Address</strong>
-        <span class="text-muted">{{address.address}}</span>
-        <span class="btn-copy" clip-copy="address.address"></span>
-      </div>
-      <!-- For normal devices -->
-      <div class="pull-right hidden-xs hidden-sm">
-        <strong>Public key</strong>
-        <span class="text-muted">{{address.publicKey}}</span>
-        <span class="btn-copy" clip-copy="address.publicKey"></span>
-      </div>
-      <!-- For small devices -->
-      <div class="pull-left pk-mobile-display hidden-md hidden-lg hidden-xl">
-        <strong>Public key</strong>
-        <span class="text-muted">{{address.publicKey}}</span>
-        <span class="btn-copy" clip-copy="address.publicKey"></span>
-      </div>
-    </div>
-    <h2>Summary <small>confirmed</small></h2>
+  <h2>Address Summary</h2>
     <div class="row">
       <div class="col-md-10">
         <div class="table-responsive">
@@ -52,6 +32,14 @@
                   <span class="owner-name">{{address.knowledge.owner}}</span>
                   <span class="owner-desc text-muted">{{address.knowledge.description}}</span>
                 </td>
+              </tr>
+              <tr>
+                <td><strong>Address</strong></td>
+                <td class="ellipsis text-right"><span class="btn-copy" clip-copy="address.address"></span>{{address.address}}</td>
+              </tr>          
+              <tr class="hidden-sm hidden-xs">
+                <td><strong>Public Key</strong></td>
+                <td class="ellipsis text-right"><span class="btn-copy" clip-copy="address.publicKey"></span>{{address.publicKey}}</td>
               </tr>
               <tr>
                 <td><strong>Total balance</strong></td>
@@ -69,7 +57,11 @@
         <qrcode size="160" data="{{address.address}}"></qrcode>
       </div>
     </div>
-    <div class="delegate" data-ng-if="address.delegate">
+    <div class="hidden-md hidden-lg hidden-xl">
+      <strong>Public Key</strong>
+      <span class="pk-mobile-display">{{address.publicKey}}</span>
+    </div>
+<div class="delegate" data-ng-if="address.delegate">
       <h2>Delegate</h2>
       <div class="row">
         <div class="col-md-12">


### PR DESCRIPTION
To see how we got here see: https://github.com/LiskHQ/lisk-explorer/pull/59
Changes made to make page layout match with QR code and remove Address/balance confusion. 

![image](https://cloud.githubusercontent.com/assets/7875147/21916294/41b520f4-d905-11e6-8d4a-1ef2e00b7023.png)

**Public key field detaches and moves below QR on mobile**

![mobilepub11](https://cloud.githubusercontent.com/assets/7875147/21916365/bb92a95a-d905-11e6-81a7-3482ed919f2c.png)

