### PR TITLE
Add community fund to known.json - Closes #82

### DIFF
--- a/known.json
+++ b/known.json
@@ -9,5 +9,6 @@
     "13724180208900114961L" : { "owner" : "Yobit", "description" : "Main Wallet" },
     "15434119221255134066L" : { "owner" : "Bounty Fund", "description" : "LiskHQ" },
     "15434119221255134066L" : { "owner" : "Adviser Fund", "description" : "LiskHQ" },
-    "5726759782318848681L"  : { "owner" : "Lisk Foundation", "description" : "LiskHQ" }
+    "5726759782318848681L"  : { "owner" : "Lisk Foundation", "description" : "LiskHQ" },
+    "15841793714384967784L"  : { "owner" : "Lisk Community Fund", "description" : "LiskHQ" }    
 }


### PR DESCRIPTION
To improve visibility of the community fund we should add this to the known.json.

Closes issues #82 