### PR TITLE
Hide Public key field if not present

### DIFF
--- a/public/views/address.html
+++ b/public/views/address.html
@@ -37,7 +37,7 @@ data-ng-if="address.balance >= 0" data-ng-init="hideSNavbar=0">
                 <td><strong>Address</strong></td>
                 <td class="text-right"></span>{{address.address}}&nbsp;<span class="btn-copy" clip-copy="address.address"></span></td>
               </tr>
-              <tr class="hidden-xs">
+              <tr class="hidden-xs" data-ng-if="!(address.publicKey >= 0)">
                 <td><strong>Public Key</strong></td>
                 <td class="text-right">{{address.publicKey}}&nbsp;<span class="btn-copy" clip-copy="address.publicKey"></span></td>
               </tr>
@@ -51,7 +51,7 @@ data-ng-if="address.balance >= 0" data-ng-init="hideSNavbar=0">
               </tr>
             </tbody>
           </table>
-     <div class="hidden-sm hidden-md hidden-lg hidden-xl pk-mobile-style">
+     <div class="hidden-sm hidden-md hidden-lg hidden-xl pk-mobile-style" data-ng-if="!(address.publicKey >= 0)">
 	<span class="pk-mobile-display"><strong>Public&nbsp;Key</strong>&nbsp;&nbsp;{{address.publicKey}}</span>
      </div>
     </div>

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -37,7 +37,7 @@ data-ng-if="address.balance >= 0" data-ng-init="hideSNavbar=0">
                 <td><strong>Address</strong></td>
                 <td class="text-right"></span>{{address.address}}&nbsp;<span class="btn-copy" clip-copy="address.address"></span></td>
               </tr>
-              <tr class="hidden-xs" data-ng-if="!(address.publicKey >= 0)">
+              <tr class="hidden-xs" data-ng-if="address.publicKey">
                 <td><strong>Public Key</strong></td>
                 <td class="text-right">{{address.publicKey}}&nbsp;<span class="btn-copy" clip-copy="address.publicKey"></span></td>
               </tr>
@@ -51,7 +51,7 @@ data-ng-if="address.balance >= 0" data-ng-init="hideSNavbar=0">
               </tr>
             </tbody>
           </table>
-     <div class="hidden-sm hidden-md hidden-lg hidden-xl pk-mobile-style" data-ng-if="!(address.publicKey >= 0)">
+     <div class="hidden-sm hidden-md hidden-lg hidden-xl pk-mobile-style" data-ng-if="address.publicKey">
 	<span class="pk-mobile-display"><strong>Public&nbsp;Key</strong>&nbsp;&nbsp;{{address.publicKey}}</span>
      </div>
     </div>


### PR DESCRIPTION
In response to #86 this hides the respective full and mobile versions of the public key display field when they are unknown.

Closes https://github.com/LiskHQ/lisk-explorer/issues/86 //Mq