### PR TITLE
Switching tx's to table view

### DIFF
--- a/public/src/css/no-more-tables.css
+++ b/public/src/css/no-more-tables.css
@@ -1,0 +1,49 @@
+@media only screen and (max-width: 800px) {
+    
+    /* Force table to not be like tables anymore */
+	#no-more-tables table, 
+	#no-more-tables thead, 
+	#no-more-tables tbody, 
+	#no-more-tables th, 
+	#no-more-tables td, 
+	#no-more-tables tr { 
+		display: block; 
+	}
+ 
+	/* Hide table headers (but not display: none;, for accessibility) */
+	#no-more-tables thead tr { 
+		position: absolute;
+		top: -9999px;
+		left: -9999px;
+	}
+ 
+	#no-more-tables tr { border: 1px solid #ccc; }
+ 
+	#no-more-tables td { 
+		/* Behave  like a "row" */
+		border: none;
+		border-bottom: 1px solid #eee; 
+		position: relative;
+		padding-left: 50%; 
+		white-space: normal;
+		text-align:left;
+	}
+ 
+	#no-more-tables td:before { 
+		/* Now like a table header */
+		position: absolute;
+		/* Top/left values mimic padding */
+		top: 6px;
+		left: 6px;
+		width: 45%; 
+		padding-right: 10px; 
+		white-space: nowrap;
+		text-align:left;
+		font-weight: bold;
+	}
+ 
+	/*
+	Label the data
+	*/
+	#no-more-tables td:before { content: attr(data-title); }
+}

--- a/public/src/css/table-mobile.css
+++ b/public/src/css/table-mobile.css
@@ -1,5 +1,11 @@
 #table-mobile .txvalues {
 	width: 100%;
+	padding: .7em 0;
+}
+
+/* Override bootstrap settings at <=320px */
+#table-mobile td:first-of-type {
+    max-width: inherit;
 }
 
 @media only screen and (max-width: 768px) {

--- a/public/src/css/table-mobile.css
+++ b/public/src/css/table-mobile.css
@@ -2,7 +2,7 @@
 	width: 100%;
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 768px) {
     
     /* Force table to not be like tables anymore */
 	#table-mobile table, 

--- a/public/src/css/table-mobile.css
+++ b/public/src/css/table-mobile.css
@@ -23,7 +23,7 @@
  
 	#table-mobile tr { border: 1px solid #ccc; }
  
-	 td { 
+	#table-mobile td { 
 		/* Behave  like a "row" */
 		border: none;
 		border-bottom: 1px solid #eee; 
@@ -36,7 +36,6 @@
 	#table-mobile td:before { 
 		/* Now like a table header */
 		position: absolute;
-		/* Top/left values mimic padding */
 		top: 8px;
 		left: 6px;
 		width: 35%; 
@@ -46,12 +45,14 @@
 		font-weight: bold;
 	}
 	
+	#table-mobile td:first-child:before { 
+		top: 11px;
+	}
+	
 	#table-mobile .txvalues {
 		width: inherit;
 	}
  
-	/*
-	Label the data
-	*/
+	/* Label the data */
 	#table-mobile td:before { content: attr(data-title); }
 }

--- a/public/src/css/table-mobile.css
+++ b/public/src/css/table-mobile.css
@@ -1,49 +1,57 @@
+#table-mobile .txvalues {
+	width: 100%;
+}
+
 @media only screen and (max-width: 800px) {
     
     /* Force table to not be like tables anymore */
-	#no-more-tables table, 
-	#no-more-tables thead, 
-	#no-more-tables tbody, 
-	#no-more-tables th, 
-	#no-more-tables td, 
-	#no-more-tables tr { 
+	#table-mobile table, 
+	#table-mobile thead, 
+	#table-mobile tbody, 
+	#table-mobile th, 
+	#table-mobile td, 
+	#table-mobile tr { 
 		display: block; 
 	}
  
 	/* Hide table headers (but not display: none;, for accessibility) */
-	#no-more-tables thead tr { 
+	#table-mobile thead tr { 
 		position: absolute;
 		top: -9999px;
 		left: -9999px;
 	}
  
-	#no-more-tables tr { border: 1px solid #ccc; }
+	#table-mobile tr { border: 1px solid #ccc; }
  
-	#no-more-tables td { 
+	 td { 
 		/* Behave  like a "row" */
 		border: none;
 		border-bottom: 1px solid #eee; 
 		position: relative;
-		padding-left: 50%; 
+		padding-left: 40%; 
 		white-space: normal;
 		text-align:left;
 	}
  
-	#no-more-tables td:before { 
+	#table-mobile td:before { 
 		/* Now like a table header */
 		position: absolute;
 		/* Top/left values mimic padding */
-		top: 6px;
+		top: 8px;
 		left: 6px;
-		width: 45%; 
+		width: 35%; 
 		padding-right: 10px; 
 		white-space: nowrap;
 		text-align:left;
 		font-weight: bold;
 	}
+	
+	#table-mobile .txvalues {
+		width: inherit;
+	}
  
 	/*
 	Label the data
 	*/
-	#no-more-tables td:before { content: attr(data-title); }
+	#table-mobile td:before { content: attr(data-title); }
 }

--- a/public/src/css/table-mobile.css
+++ b/public/src/css/table-mobile.css
@@ -27,7 +27,14 @@
 		left: -9999px;
 	}
  
-	#table-mobile tr { border: 1px solid #ccc; }
+	#table-mobile tr:first-child { border-width: 1px 1px 3px 1px;}
+	
+	#table-mobile tr { 
+		border: solid #ccc; 
+		border-width: 3px 1px;
+	}
+	
+	#table-mobile tr:last-child { border-width:  3px 1px 1px 1px;}
  
 	#table-mobile td { 
 		/* Behave  like a "row" */

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -119,7 +119,7 @@
       </div>
     </div>
     <h2>Details</h2>
-	<div id="no-more-tables" class="table-responsive">
+	<div id="table-mobile" class="table-responsive">
 		<table class="table">
 			<thead>
 			  <tr>

--- a/public/views/transaction.html
+++ b/public/views/transaction.html
@@ -119,8 +119,24 @@
       </div>
     </div>
     <h2>Details</h2>
-    <div class="block-tx" data-ng-if="tx.id">
-      <div data-ng-include src="'/views/transaction/tx.html'"></div>
-    </div>
+	<div id="no-more-tables" class="table-responsive">
+		<table class="table">
+			<thead>
+			  <tr>
+				<th>Transaction ID</th>
+				<th>Sender</th>
+				<th>Recipient</th>
+				<th>Amount</th>
+				<th>Fee</th>
+				<th>Confirmations</th>
+				<th>Date</th>
+			  </tr>
+			</thead>
+			<tbody>
+			<tr data-ng-if="tx.id" data-ng-include="'/views/transaction/tx.html'">
+			</tr>
+			</tbody>
+		</table>
+	</div>
   </div>
 </section>

--- a/public/views/transaction/list.html
+++ b/public/views/transaction/list.html
@@ -1,7 +1,21 @@
 <div class="alert alert-warning" data-ng-if="!txs.loading && !txs.results.length">There are no transactions involving this {{txs.parent}}.</div>
-<div class="block-tx" data-ng-if="txs.results[0].id" data-ng-repeat="tx in txs.results track by tx.id">
-  <div data-ng-include src="'/views/transaction/tx.html'"></div>
-</div>
+<table class="table">
+	<thead>
+	  <tr>
+		<th>TX</th>
+		<th>Sender</th>
+		<th>Recipient</th>
+		<th>Fee</th>
+		<th>Amount</th>
+		<th>Confirms</th>
+		<th>Age</th>
+	  </tr>
+	</thead>
+	<tbody>
+	<tr data-ng-if="txs.results[0].id" data-ng-repeat="tx in txs.results track by tx.id" data-ng-include="'/views/transaction/tx.html'">
+	</tr>
+	</tbody>
+</table>
 <div class="progress progress-striped active" data-ng-if="txs.loading">
   <div class="progress-bar progress-bar-loading" style="width: 100%">
     <span>Loading Transactions...</span>

--- a/public/views/transaction/list.html
+++ b/public/views/transaction/list.html
@@ -1,13 +1,13 @@
 <div class="alert alert-warning" data-ng-if="!txs.loading && !txs.results.length">There are no transactions involving this {{txs.parent}}.</div>
-<div class="table-responsive">
+<div id="no-more-tables" class="table-responsive">
 	<table class="table">
 		<thead>
 		  <tr>
 			<th>Transaction ID</th>
 			<th>Sender</th>
 			<th>Recipient</th>
-			<th>Fee</th>
 			<th>Amount</th>
+			<th>Fee</th>
 			<th>Confirmations</th>
 			<th>Date</th>
 		  </tr>

--- a/public/views/transaction/list.html
+++ b/public/views/transaction/list.html
@@ -1,21 +1,23 @@
 <div class="alert alert-warning" data-ng-if="!txs.loading && !txs.results.length">There are no transactions involving this {{txs.parent}}.</div>
-<table class="table">
-	<thead>
-	  <tr>
-		<th>TX</th>
-		<th>Sender</th>
-		<th>Recipient</th>
-		<th>Fee</th>
-		<th>Amount</th>
-		<th>Confirms</th>
-		<th>Age</th>
-	  </tr>
-	</thead>
-	<tbody>
-	<tr data-ng-if="txs.results[0].id" data-ng-repeat="tx in txs.results track by tx.id" data-ng-include="'/views/transaction/tx.html'">
-	</tr>
-	</tbody>
-</table>
+<div class="table-responsive">
+	<table class="table">
+		<thead>
+		  <tr>
+			<th>Transaction ID</th>
+			<th>Sender</th>
+			<th>Recipient</th>
+			<th>Fee</th>
+			<th>Amount</th>
+			<th>Confirmations</th>
+			<th>Date</th>
+		  </tr>
+		</thead>
+		<tbody>
+		<tr data-ng-if="txs.results[0].id" data-ng-repeat="tx in txs.results track by tx.id" data-ng-include="'/views/transaction/tx.html'">
+		</tr>
+		</tbody>
+	</table>
+</div>
 <div class="progress progress-striped active" data-ng-if="txs.loading">
   <div class="progress-bar progress-bar-loading" style="width: 100%">
     <span>Loading Transactions...</span>

--- a/public/views/transaction/list.html
+++ b/public/views/transaction/list.html
@@ -1,5 +1,5 @@
 <div class="alert alert-warning" data-ng-if="!txs.loading && !txs.results.length">There are no transactions involving this {{txs.parent}}.</div>
-<div id="no-more-tables" class="table-responsive">
+<div id="table-mobile" class="table-responsive">
 	<table class="table">
 		<thead>
 		  <tr>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -6,11 +6,14 @@
 	<td data-ng-show="tx.type == 0"><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
 	<td data-ng-show="tx.type >= 1">{{tx | txType}}</td>	
 	<td>{{tx.fee | currency:currency}}{{currency.symbol}}</td>
-	<td class="txvalues" style="display: table-cell;" data-ng-class="{
+	<td>
+		<div class="txvalues" style="width:100%" data-ng-class="{
       'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
       'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
       'txvalues-default': tx.type != 0
-    }">{{tx.amount | currency:currency}}{{currency.symbol}}</td>
+    }">{{tx.amount | currency:currency}}{{currency.symbol}}
+    	</div>
+    </td>
 	<td>
 		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
 		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}}</span>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -1,68 +1,17 @@
-<div class="line-bot row" data-ng-hide="!tx">
-  <div class="col-xs-7">
-    <div class="ellipsis">
-      <a class="txid" href="/tx/{{tx.id}}">{{tx.id}}</a>
-      <span class="btn-copy" clip-copy="tx.id"></span>
-    </div>
-  </div>
-  <div class="col-xs-5">
-    <div class="ellipsis text-right">
-      <span class="text-muted">{{tx.timestamp | timeAgo }}</span>
-    </div>
-  </div>
-</div>
-<div class="row line-mid" data-ng-hide="!tx">
-  <div class="col-md-5">
-    <div class="row">
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <div class="pull-right">{{tx.amount | currency:currency}} {{currency.symbol}}</div>
-          <div class="ellipsis">
-            <a href="/address/{{tx.senderId}}">{{tx | txSender}}</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="col-md-1">
-    <div class="hidden-xs hidden-sm text-center">
-    <span class="lead glyphicon glyphicon-arrow-right text-muted" data-ng-class="{
-      'text-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
-      'text-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
-      'text-muted': tx.type != 0
-    }"></span>
-    </div>
-    <div class="hidden-md hidden-lg text-center">
-      <span class="lead glyphicon glyphicon-arrow-down text-muted" data-ng-class="{
-        'text-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
-        'text-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
-        'text-muted': tx.type != 0
-      }"></span>
-    </div>
-  </div>
-  <div class="col-md-6">
-    <div class="row">
-      <div>
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <div class="pull-right">{{tx.amount | currency:currency}} {{currency.symbol}}</div>
-            <div class="ellipsis" data-ng-show="tx.type == 0">
-              <a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a>
-            </div>
-            <div class="ellipsis" data-ng-show="tx.type >= 1">{{tx | txType}}</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="line-top row" data-ng-hide="!tx">
-  <div class="col-xs-12 col-sm-4 col-md-4">
-    <span class="txvalues txvalues-default">Fee: {{tx.fee | currency:currency}} {{currency.symbol}}</span>
-  </div>
-  <div class="col-xs-12 col-sm-8 col-md-8 text-right">
-    <span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="txvalues txvalues-success">{{block.confirmations || tx.confirmations}} Confirmations</span>
-    <span data-ng-if="!block.confirmations && !tx.confirmations" class="txvalues txvalues-danger">Unconfirmed Transaction!</span>
-    <span class="txvalues txvalues-primary">{{tx.amount | currency:currency}} {{currency.symbol}}</span>
-  </div>
-</div>
+	<td>
+		<a class="txid" href="/tx/{{tx.id}}">{{tx.id}}</a>
+		<span class="btn-copy" clip-copy="tx.id"></span>
+	</td>
+	<td><a href="/address/{{tx.senderId}}">{{tx | txSender}}</a></td>
+	<td><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
+	<td>{{tx.fee | currency:currency}} {{currency.symbol}}</td>
+	<td class="txvalues" style="display: table-cell;" data-ng-class="{
+      'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
+      'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
+      'txvalues-default': tx.type != 0
+    }">{{tx.amount | currency:currency}} {{currency.symbol}}</td>
+	<td>
+		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
+		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}} Confirmations</span>
+	</td>
+	<td>{{tx.timestamp | timeAgo }}</td>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -18,4 +18,4 @@
 		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
 		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}}</span>
 	</td>
-	<td data-title="Daye">{{tx.timestamp | timeAgo }}</td>
+	<td data-title="Day">{{tx.timestamp | timeAgo }}</td>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -3,15 +3,16 @@
 		<span class="btn-copy" clip-copy="tx.id"></span>
 	</td>
 	<td><a href="/address/{{tx.senderId}}">{{tx | txSender}}</a></td>
-	<td><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
-	<td>{{tx.fee | currency:currency}} {{currency.symbol}}</td>
+	<td data-ng-show="tx.type == 0"><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
+	<td data-ng-show="tx.type >= 1">{{tx | txType}}</td>	
+	<td>{{tx.fee | currency:currency}}{{currency.symbol}}</td>
 	<td class="txvalues" style="display: table-cell;" data-ng-class="{
       'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
       'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
       'txvalues-default': tx.type != 0
-    }">{{tx.amount | currency:currency}} {{currency.symbol}}</td>
+    }">{{tx.amount | currency:currency}}{{currency.symbol}}</td>
 	<td>
 		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
-		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}} Confirmations</span>
+		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}}</span>
 	</td>
 	<td>{{tx.timestamp | timeAgo }}</td>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -9,13 +9,13 @@
 		<div class="txvalues" style="width:100%" data-ng-class="{
       'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
       'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
-      'txvalues-default': tx.type != 0
-    }">{{tx.amount | currency:currency}}{{currency.symbol}}
+      'txvalues-default': tx.type != 0 || $parent.address.address === undefined
+    }">{{tx.amount | currency:currency}} {{currency.symbol}}
     	</div>
     </td>
-    <td data-title="Fee">{{tx.fee | currency:currency}}{{currency.symbol}}</td>
+    <td data-title="Fee">{{tx.fee | currency:currency}} {{currency.symbol}}</td>
 	<td data-title="Confirmations">
 		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
 		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}}</span>
 	</td>
-	<td data-title="Day">{{tx.timestamp | timeAgo }}</td>
+	<td data-title="Date">{{tx.timestamp | timestamp }}</td>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -1,12 +1,11 @@
-	<td>
+	<td data-title="Transaction ID">
 		<a class="txid" href="/tx/{{tx.id}}">{{tx.id}}</a>
 		<span class="btn-copy" clip-copy="tx.id"></span>
 	</td>
-	<td><a href="/address/{{tx.senderId}}">{{tx | txSender}}</a></td>
-	<td data-ng-show="tx.type == 0"><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
-	<td data-ng-show="tx.type >= 1">{{tx | txType}}</td>	
-	<td>{{tx.fee | currency:currency}}{{currency.symbol}}</td>
-	<td>
+	<td data-title="Sender"><a href="/address/{{tx.senderId}}">{{tx | txSender}}</a></td>
+	<td data-title="Recipient" data-ng-show="tx.type == 0"><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
+	<td data-title="Recipient" data-ng-show="tx.type >= 1">{{tx | txType}}</td>	
+	<td data-title="Amount">
 		<div class="txvalues" style="width:100%" data-ng-class="{
       'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
       'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
@@ -14,8 +13,9 @@
     }">{{tx.amount | currency:currency}}{{currency.symbol}}
     	</div>
     </td>
-	<td>
+    <td data-title="Fee">{{tx.fee | currency:currency}}{{currency.symbol}}</td>
+	<td data-title="Confirmations">
 		<span data-ng-if="!block.confirmations && !tx.confirmations" class="text-danger">Unconfirmed Transaction!</span>
 		<span data-ng-if="block.confirmations > 0 || tx.confirmations > 0" class="text-success">{{block.confirmations || tx.confirmations}}</span>
 	</td>
-	<td>{{tx.timestamp | timeAgo }}</td>
+	<td data-title="Daye">{{tx.timestamp | timeAgo }}</td>

--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -6,7 +6,7 @@
 	<td data-title="Recipient" data-ng-show="tx.type == 0"><a href="/address/{{tx.recipientId}}">{{tx | txRecipient}}</a></td>
 	<td data-title="Recipient" data-ng-show="tx.type >= 1">{{tx | txType}}</td>	
 	<td data-title="Amount">
-		<div class="txvalues" style="width:100%" data-ng-class="{
+		<div class="txvalues" data-ng-class="{
       'txvalues-danger': tx.type == 0 && $parent.address.address == tx.senderId && tx.senderId != tx.recipientId,
       'txvalues-success': tx.type == 0 && $parent.address.address && tx.senderId != $parent.address.address,
       'txvalues-default': tx.type != 0 || $parent.address.address === undefined


### PR DESCRIPTION
Have transactions for an account be formatted as a table instead of the blocks.  After seeing it, I prefer this look, but it's more of a change than the other PR.
I still have an inline style, but I didn't want to change too many files at once since I only briefly tested this in one browser on one computer.
Wasn't sure about keeping the slightly rounded corners on the amount boxes too