### PR TITLE
Make delegate monitor forks prone - Closes #30

### DIFF
--- a/lib/api/candles.js
+++ b/lib/api/candles.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
     var exchanges = {
         poloniex: new candles.poloniex(app.locals.redis),
         bittrex:  new candles.bittrex(app.locals.redis)
-    }
+    };
 
     this.getCandles = function (params, error, success) {
         var options = thisOptions(params.e, params.d);

--- a/lib/api/orders.js
+++ b/lib/api/orders.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
     var exchanges = {
         poloniex: new orders.poloniex(app.locals.redis),
         bittrex:  new orders.bittrex(app.locals.redis)
-    }
+    };
 
     this.getOrders = function (e, error, success) {
         if (!config.marketWatcher.enabled) {

--- a/public/src/js/services/delegateMonitor.js
+++ b/public/src/js/services/delegateMonitor.js
@@ -3,7 +3,7 @@
 var DelegateMonitor = function ($scope, $rootScope, forgingMonitor) {
     this.updateActive = function (active) {
         _.each(active.delegates, function (d) {
-            d.forgingStatus = forgingMonitor.getStatus(d);
+            d.forgingStatus = forgingMonitor.getStatus(d, $scope.lastBlock);
             d.proposal = _.find ($rootScope.delegateProposals, function (p) {
               return p.name === d.username.toLowerCase ();
             });
@@ -52,16 +52,14 @@ var DelegateMonitor = function ($scope, $rootScope, forgingMonitor) {
 
     this.updateLastBlocks = function (delegate) {
         _.each($scope.activeDelegates, function (d) {
-            d.forgingStatus = forgingMonitor.getStatus(d);
+            d.forgingStatus = forgingMonitor.getStatus(d, $scope.lastBlock);
         });
 
         var existing = _.find($scope.activeDelegates, function (d) {
             return d.publicKey === delegate.publicKey;
         });
         if (existing) {
-            existing.blocksAt = delegate.blocksAt;
-            existing.blocks = delegate.blocks;
-            existing.forgingStatus = forgingMonitor.getStatus(delegate);
+            existing.forgingStatus = forgingMonitor.getStatus(delegate, $scope.lastBlock);
         }
         updateForgingTotals($scope.activeDelegates);
         updateForgingProgress($scope.forgingTotals);

--- a/public/src/js/services/forgingMonitor.js
+++ b/public/src/js/services/forgingMonitor.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var ForgingMonitor = function (forgingStatus) {
-    this.getStatus = function (delegate) {
-        return forgingStatus(delegate);
+    this.getStatus = function (delegate, lastBlock) {
+        return forgingStatus(delegate, lastBlock);
     };
 
     this.getforgingTotals = function (delegates) {

--- a/public/src/js/services/forgingStatus.js
+++ b/public/src/js/services/forgingStatus.js
@@ -2,53 +2,41 @@
 
 angular.module('lisk_explorer.tools').service('forgingStatus',
   function ($rootScope, epochStampFilter, roundFilter) {
-      return function (delegate) {
+      return function (delegate, lastBlock) {
           var status = { updatedAt: delegate.blocksAt },
               statusAge = 0, blockAge = 0;
 
-          if (delegate.blocksAt && _.size(delegate.blocks) > 0) {
-              status.lastBlock = _.first(delegate.blocks);
-              status.blockAt   = epochStampFilter(status.lastBlock.timestamp);
-              status.networkRound = roundFilter($rootScope.blockStatus.height);
-              status.delegateRound = roundFilter(status.lastBlock.height);
-              status.awaitingSlot = status.networkRound - status.delegateRound;
+          if (delegate.block) {
+              status.lastBlock     = delegate.block;
+              status.blockAt       = epochStampFilter(delegate.block.timestamp);
+              status.networkRound  = roundFilter(lastBlock ? lastBlock.height : 0);
+              status.delegateRound = roundFilter(delegate.block.height);
+              status.awaitingSlot  = status.networkRound - status.delegateRound;
 
-              statusAge = moment().diff(delegate.blocksAt, 'minutes');
+              statusAge = moment().diff(delegate.blockAt, 'minutes');
               blockAge  = moment().diff(status.blockAt, 'minutes');
           } else {
               status.lastBlock = null;
           }
 
-          if (status.awaitingSlot === 0) {
+          if (status.awaitingSlot <= 0) {
               // Forged block in current round
               status.code = 0;
-          } else if (!delegate.isRoundDelegate && status.awaitingSlot === 1) {
+          } else if (!delegate.isRoundDelegate && (status.awaitingSlot === 1 || delegate.missedblocks === 1)) {
               // Missed block in current round
               status.code = 1;
-          } else if (!delegate.isRoundDelegate && status.awaitingSlot > 1) {
+          } else if ((!delegate.isRoundDelegate && status.awaitingSlot > 1) || (delegate.producedblocks === 0 && delegate.missedblocks > 1)) {
               // Missed block in current and last round = not forging
               status.code = 2;
           } else if (status.awaitingSlot === 1) {
               // Awaiting slot, but forged in last round
               status.code = 3;
-          } else if (status.awaitingSlot === 2) {
+          } else if (status.awaitingSlot === 2 || delegate.missedblocks === 1) {
               // Awaiting slot, but missed block in last round
               status.code = 4;
-          } else if (!status.blockAt || !status.updatedAt) {
+          } else if (!status.blockAt) {
               // Awaiting status or unprocessed
               status.code = 5;
-          // For delegates which not forged a signle block yet (statuses 0,3,5 not apply here)
-          } else if (!status.blockAt && status.updatedAt) {
-            if (!delegate.isRoundDelegate && delegate.missedblocks === 1) {
-              // Missed block in current round
-              status.code = 1;
-            } else if (delegate.missedblocks > 1) {
-              // Missed more than 1 block = not forging
-              status.code = 2;
-            } else if (delegate.missedblocks === 1) {
-              // Missed block in previous round
-              status.code = 4;
-            }
           } else {
               // Not Forging
               status.code = 2;

--- a/sockets/delegateMonitor.js
+++ b/sockets/delegateMonitor.js
@@ -164,7 +164,7 @@ module.exports = function (app, connectionHandler, socket) {
         	running.getDelegateBlocks = false;
         	return cb('getDelegateBlocks - failed to get active delegates');
         }
-        app.db.any (sql.getLastBlocks ({delegates: result}))
+        app.db.any (sql.getLastDelegateBlocks ({delegates: result}))
             .then (function (result) {
                 var cum_balance = 0;
                 _.each(result, function (row) {

--- a/sql/delegates.js
+++ b/sql/delegates.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var squel = require ('squel').useFlavour ('postgres');
 
 var DelegatesSql = {

--- a/sql/delegates.js
+++ b/sql/delegates.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var _ = require('lodash');
+var squel = require ('squel').useFlavour ('postgres');
+
+var DelegatesSql = {
+	getLastBlocks: function (params) {
+		return squel.select()
+			.from('mem_accounts', 'a')
+			.field(squel.select()
+				.from('blocks', 'b')
+				.field('ARRAY[b.timestamp, b.height]')
+				.where('b."generatorPublicKey" = a."publicKey"')
+				.order('b.height', false)
+				.limit(1)
+			, 'block')
+			.field('a.address', 'address')
+			.where('a.address IN ?', params.delegates)
+			.where('a."isDelegate" = 1')
+			.order('a.vote', false).limit(101)
+			.toString();
+	}
+};
+
+module.exports = DelegatesSql;

--- a/sql/delegates.js
+++ b/sql/delegates.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var squel = require ('squel').useFlavour ('postgres');
 
 var DelegatesSql = {
-	getLastBlocks: function (params) {
+	getLastDelegateBlocks: function (params) {
 		return squel.select()
 			.from('mem_accounts', 'a')
 			.field(squel.select()
@@ -17,7 +17,7 @@ var DelegatesSql = {
 			.field('a.address', 'address')
 			.where('a.address IN ?', params.delegates)
 			.where('a."isDelegate" = 1')
-			.order('a.vote', false).limit(101)
+			.limit(params.delegates.length)
 			.toString();
 	}
 };

--- a/sql/index.js
+++ b/sql/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-
+	delegates: require('./delegates.js')
 };


### PR DESCRIPTION
Improved delegate monitor:
- using SQL query to acquire active delegates blocks
- improve forging statuses handling when delegate not forged a block yet

Closes https://github.com/LiskHQ/lisk-explorer/issues/30