### PR TITLE
State corresponding address on delegate page, fixes 112

### DIFF
--- a/public/views/delegate.html
+++ b/public/views/delegate.html
@@ -11,6 +11,12 @@
                                 <td class="text-right" ng-bind-html="address.delegate.username | proposal:delegateProposals"></td>
                             </tr>
                             <tr>
+                                <td><strong>Address</strong></td>
+                                <td class="text-right">
+                                    <a href="/address/{{address.address}}">{{address.address}}</a>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td><strong>Uptime</strong></td>
                                 <td class="text-right">{{address.delegate.productivity || 0.00}}%</td>
                             </tr>


### PR DESCRIPTION
add a new row stating the address to whom this delegate belongs, anchored to the corresponding address page