### PR TITLE
Breadcrumb fixings - Closes #127 and #141

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -1075,3 +1075,6 @@ a.sort-order span.reverse:after {
     vertical-align: middle;
     margin-top: -5px;
 }
+.breadcrumb > li + li:before {
+    padding: 0 0 0 7px;
+}


### PR DESCRIPTION
 - Add possibility to set breadcrumb parameters using the callback of any sync function
 - Fix typos
 - Unify the spaces on both sides of the separators

Closes #127
Closes #141