### PR TITLE
Fix tests, fix candles:build, improve candles performance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,9 +69,6 @@ module.exports = function (grunt) {
         },
     });
 
-    // Making grunt default to force in order not to break the project.
-    grunt.option('force', true);
-
     // Register tasks for travis.
     grunt.registerTask('travis', ['jshint', 'mochaTest']);
 };

--- a/config.global.js
+++ b/config.global.js
@@ -6,6 +6,6 @@ config.freegeoip = {};
 config.redis = {};
 config.proposals = {};
 config.exchangeRates = {exchanges: { LSK: {}, BTC: {}}};
-config.marketWatcher = {exchanges: {}, candles: {}, orders: {}};
+config.marketWatcher = {exchanges: {}, candles: { poloniex: {} }, orders: {}};
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -38,6 +38,7 @@ config.marketWatcher.enabled = true; // Market watcher support (true - enabled, 
 config.marketWatcher.exchanges.poloniex = true; // Poloniex exchange support (true - enabled, false - disabled)
 config.marketWatcher.exchanges.bittrex  = true; // Bittrex exchange support (true - enabled, false - disabled)
 config.marketWatcher.candles.updateInterval = 30000; // Interval in ms for updating candlestick data (default: 30 seconds)
+config.marketWatcher.candles.poloniex.buildTimeframe = 60*60*24*30; // Build candles based on trades form last 30 days
 config.marketWatcher.orders.updateInterval  = 15000;  // Interval in ms for updating order book data (default: 15 seconds)
 
 // Delegate Proposals

--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -11,7 +11,8 @@ function AbstractCandles (client) {
     this.name  = 'exchange';
     this.key   = this.name + 'Candles';
     this.url   = '';
-    this.start = 0;
+    this.start = null;
+    this.end   = null;
     this.last  = null;
 
     this.response = {
@@ -29,9 +30,7 @@ function AbstractCandles (client) {
     this.duration  = 'minute';
     this.durations = ['minute', 'hour', 'day'];
 
-    this.retrieveTrades = function (start, cb) {
-        if (!start) { start = self.start || 0; }
-
+    this.retrieveTrades = function (start, end, cb) {
         var found   = false,
             results = [];
 
@@ -39,9 +38,11 @@ function AbstractCandles (client) {
 
         async.doUntil(
             function (next) {
+                console.log ('Candles: Start: ' + (start ? new Date(start*1000).toISOString() : 'N/A') + ' End: ' + (end ? new Date(end*1000).toISOString() : 'N/A'));
+
                 request.get({
-                    url : self.url + start,
-                    json : true
+                    url: self.url + (start ? '&start=' + start : '') + (end ? '&end=' + end : ''),
+                    json: true
                 }, function (err, resp, body) {
                     if (err || resp.statusCode !== 200) {
                         return next(err || 'Response was unsuccessful');
@@ -59,9 +60,9 @@ function AbstractCandles (client) {
                     }
 
                     if (self.validTrades(results, data)) {
-                        console.log('Candles:', start.toString(), '=> Found', data.length.toString(), 'trades');
+                        console.log('Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades');
                         results = self.acceptTrades(results, data);
-                        start   = self.nextStart(data);
+                        end     = self.nextEnd(data);
                         return next();
                     } else {
                         found = true;
@@ -83,8 +84,8 @@ function AbstractCandles (client) {
         );
     };
 
-    this.nextStart = function (data) {
-        return 0;
+    this.nextEnd = function (data) {
+        return null;
     };
 
     this.rejectTrades = function (data) {
@@ -151,7 +152,7 @@ function AbstractCandles (client) {
                 btcVolume  : _.reduce(period, function (memo, t) { return (memo + parseFloat(t[self.candle.amount]) * parseFloat(t[self.candle.price])); }, 0.0).toFixed(8),
                 firstTrade : _.first(period)[self.candle.id],
                 lastTrade  : _.last(period)[self.candle.id],
-                nextStart  : self.nextStart(period),
+                nextEnd    : self.nextEnd(period),
                 numTrades  : _.size(period)
             };
         });
@@ -201,39 +202,53 @@ function AbstractCandles (client) {
     };
 
     this.buildCandles = function (cb) {
-        async.eachSeries(self.durations, function (duration, callback) {
-            self.duration = duration;
-            _buildCandles(callback);
-        }, function (err, results) {
+        async.waterfall([
+            function (waterCb) {
+                return self.retrieveTrades(self.start, self.end, waterCb);
+            },
+            function (trades, waterCb) {
+                async.eachSeries(self.durations, function (duration, eachCb) {
+                    self.duration = duration;
+                    return _buildCandles(trades, eachCb);
+                }, function (err, results) {
+                    if (err) {
+                        return waterCb(err);
+                    } else {
+                        return waterCb(null);
+                    }
+                });
+            }
+        ],
+        function (err, results) {
             if (err) {
                 return cb(err);
             } else {
-                return cb(null);
+                return cb(null, results);
             }
         });
     };
 
-    var _buildCandles = function (cb) {
+    var _buildCandles = function (trades, cb) {
         console.log('Candles:', 'Building', self.duration, 'candles for', self.name + '...');
 
         async.waterfall([
-            function (callback) {
+            function (waterCb) {
                 client.DEL(self.candleKey(), function (err, res) {
                     if (err) {
-                        return callback(err);
+                        return waterCb(err);
                     } else {
-                        self.retrieveTrades(null, callback);
+                        return waterCb();
                     }
                 });
             },
-            function (results, callback) {
-                self.groupTrades(results, callback);
+            function (waterCb) {
+                return self.groupTrades(trades, waterCb);
             },
-            function (results, callback) {
-                self.sumTrades(results, callback);
+            function (results, waterCb) {
+                return self.sumTrades(results, waterCb);
             },
-            function (results, callback) {
-                self.saveCandles(results, callback);
+            function (results, waterCb) {
+                return self.saveCandles(results, waterCb);
             }
         ],
         function (err, results) {
@@ -246,21 +261,6 @@ function AbstractCandles (client) {
     };
 
     this.updateCandles = function (cb) {
-        async.eachSeries(self.durations, function (duration, callback) {
-            self.duration = duration;
-            _updateCandles(callback);
-        }, function (err, results) {
-            if (err) {
-                return cb(err);
-            } else {
-                return cb(null);
-            }
-        });
-    };
-
-    var _updateCandles = function (cb) {
-        console.log('Candles:', 'Updating', self.duration, 'candles for', self.name + '...');
-
         async.waterfall([
             function (callback) {
                 client.LRANGE(self.candleKey(), -1, -1, function (err, reply) {
@@ -274,17 +274,43 @@ function AbstractCandles (client) {
                     }
                 });
             },
-            function (reply, callback) {
-                return self.retrieveTrades(reply.nextStart, callback);
+            function (last, waterCb) {
+                return self.retrieveTrades(last.nextEnd, null, waterCb);
             },
-            function (results, callback) {
-                return self.groupTrades(results, callback);
+            function (trades, waterCb) {
+                async.eachSeries(self.durations, function (duration, eachCb) {
+                    self.duration = duration;
+                    return _updateCandles(trades, eachCb);
+                }, function (err, results) {
+                    if (err) {
+                        return waterCb(err);
+                    } else {
+                        return waterCb(null);
+                    }
+                });
+            }
+        ],
+        function (err, results) {
+            if (err) {
+                return cb(err);
+            } else {
+                return cb(null);
+            }
+        });
+    };
+
+    var _updateCandles = function (trades, cb) {
+        console.log('Candles:', 'Updating', self.duration, 'candles for', self.name + '...');
+
+        async.waterfall([
+            function (waterCb) {
+                return self.groupTrades(trades, waterCb);
             },
-            function (results, callback) {
-                return self.sumTrades(results, callback);
+            function (results, waterCb) {
+                return self.sumTrades(results, waterCb);
             },
-            function (results, callback) {
-                return self.saveCandles(results, callback);
+            function (results, waterCb) {
+                return self.saveCandles(results, waterCb);
             }
         ],
         function (err, results) {

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -28,10 +28,6 @@ function BittrexCandles (client) {
         amount : 'Quantity'
     };
 
-    this.nextStart = function (data) {
-        return moment(_.last(data).date).add(1, 's').unix();
-    };
-
     this.acceptTrades = function (results, data) {
         return results.concat(data.reverse());
     };

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -5,14 +5,14 @@ var AbstractCandles = require('./abstract'),
     _ = require('underscore'),
     util = require('util');
 
-function PoloniexCandles (client) {
+function PoloniexCandles (client, params) {
     var self = this;
 
     AbstractCandles.apply(this, arguments);
 
-    var now = new Date();
-    this.start = Math.floor(now.setYear(now.getFullYear() - 1) / 1000); // Unix timestamp 1 year ago (in sec)
-    this.end   = Math.floor(Date.now() / 1000); // Current unix timestamp (in sec)
+    var now = Math.floor(Date.now() / 1000);
+    this.start = params && params.buildTimeframe ? (now - params.buildTimeframe) : null;
+    this.end   = now; // Current unix timestamp (in sec)
 
     this.name  = 'poloniex';
     this.key   = this.name + 'Candles';

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -10,12 +10,13 @@ function PoloniexCandles (client) {
 
     AbstractCandles.apply(this, arguments);
 
+    var now = new Date();
+    this.start = Math.floor(now.setYear(now.getFullYear() - 1) / 1000); // Unix timestamp 1 year ago (in sec)
+    this.end   = Math.floor(Date.now() / 1000); // Current unix timestamp (in sec)
+
     this.name  = 'poloniex';
     this.key   = this.name + 'Candles';
-    this.url   = 'https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_LSK&start=';
-
-    var now = new Date();
-    this.start = now.setDate(now.getDate() - 365); // 1 year ago
+    this.url   = 'https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_LSK';
 
     this.response = {
         error : 'error',
@@ -29,8 +30,8 @@ function PoloniexCandles (client) {
         amount : 'amount'
     };
 
-    this.nextStart = function (data) {
-        return moment(_.last(data).date).add(1, 's').unix();
+    this.nextEnd = function (data) {
+        return moment(_.first(data).date).subtract(1, 's').unix();
     };
 
     this.acceptTrades = function (results, data) {

--- a/tasks/candles.js
+++ b/tasks/candles.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
                     return callback(null);
                 }
 
-                var poloniex = new candles.poloniex(client);
+                var poloniex = new candles.poloniex(client, config.marketWatcher.candles.poloniex);
 
                 poloniex.buildCandles(function (err, res) {
                     if (err) {

--- a/tasks/candles.js
+++ b/tasks/candles.js
@@ -11,24 +11,34 @@ module.exports = function (grunt) {
 
         async.series([
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.poloniex) {
+                    return callback(null);
+                }
+
                 var poloniex = new candles.poloniex(client);
 
                 poloniex.buildCandles(function (err, res) {
                     if (err) {
-                        callback(err);
+                        return callback(err);
                     } else {
-                        callback(null, res);
+                        return callback(null, res);
                     }
                 });
             },
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.bittrex) {
+                    return callback(null);
+                }
+
                 var bittrex = new candles.bittrex(client);
 
                 bittrex.buildCandles(function (err, res) {
                     if (err) {
-                        callback(err);
+                        return callback(err);
                     } else {
-                        callback(null, res);
+                        return callback(null, res);
                     }
                 });
             }
@@ -48,24 +58,34 @@ module.exports = function (grunt) {
 
         async.series([
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.poloniex) {
+                    return callback(null);
+                }
+
                 var poloniex = new candles.poloniex(client);
 
                 poloniex.updateCandles(function (err, res) {
                     if (err) {
-                        callback(err);
+                        return callback(err);
                     } else {
-                        callback(null, res);
+                        return callback(null, res);
                     }
                 });
             },
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.bittrex) {
+                    return callback(null);
+                }
+
                 var bittrex = new candles.bittrex(client);
 
                 bittrex.updateCandles(function (err, res) {
                     if (err) {
-                        callback(err);
+                        return callback(err);
                     } else {
-                        callback(null, res);
+                        return callback(null, res);
                     }
                 });
             }

--- a/test/api/exchanges.js
+++ b/test/api/exchanges.js
@@ -31,7 +31,7 @@ describe('Exchanges API (Market Watcher)', function () {
                     'btcVolume',
                     'firstTrade',
                     'lastTrade',
-                    'nextStart',
+                    'nextEnd',
                     'numTrades'
                 );
             }

--- a/test/config.test
+++ b/test/config.test
@@ -38,6 +38,7 @@ config.marketWatcher.enabled = true; // Market watcher support (true - enabled, 
 config.marketWatcher.exchanges.poloniex = true; // Poloniex exchange support (true - enabled, false - disabled)
 config.marketWatcher.exchanges.bittrex  = true; // Bittrex exchange support (true - enabled, false - disabled)
 config.marketWatcher.candles.updateInterval = 30000; // Interval in ms for updating candlestick data (default: 30 seconds)
+config.marketWatcher.candles.poloniex.buildTimeframe = 60*60*24*30; // Build candles based on trades form last 30 days
 config.marketWatcher.orders.updateInterval  = 15000;  // Interval in ms for updating order book data (default: 15 seconds)
 
 // Delegate Proposals

--- a/test/config_lisk.json
+++ b/test/config_lisk.json
@@ -1,9 +1,8 @@
-
 {
     "port": 7000,
     "address": "0.0.0.0",
-    "version": "0.5.1a",
-    "minVersion": "~0.5.0",
+    "version": "0.8.2b",
+    "minVersion": ">=0.5.0",
     "fileLogLevel": "info",
     "logFileName": "logs/lisk.log",
     "consoleLogLevel": "info",
@@ -23,8 +22,10 @@
         ]
     },
     "api": {
+        "enabled": true,
         "access": {
-            "whiteList": []
+            "public": false,
+            "whiteList": ["127.0.0.1"]
         },
         "options": {
             "limits": {
@@ -36,29 +37,32 @@
         }
     },
     "peers": {
+        "enabled": true,
         "list": [
             {
-                "ip": "13.69.159.242",
+                "ip": "94.237.29.221",
                 "port": 7000
             },
             {
-                "ip": "40.68.34.176",
+                "ip": "83.136.254.104",
                 "port": 7000
             },
             {
-                "ip": "52.165.40.188",
+                "ip": "209.50.48.177",
                 "port": 7000
             },
             {
-                "ip": "13.82.31.30",
+                "ip": "94.237.64.33",
                 "port": 7000
             },
             {
-                "ip": "13.91.61.2",
+                "ip": "94.237.30.23",
                 "port": 7000
             }
         ],
-        "blackList": [],
+        "access": {
+            "blackList": []
+        },
         "options": {
             "limits": {
                 "max": 0,
@@ -75,6 +79,9 @@
         "parallelLimit": 20,
         "releaseLimit": 25,
         "relayLimit": 2
+    },
+    "transactions": {
+        "maxTxsPerQueue": 1000
     },
     "forging": {
         "force": false,
@@ -100,9 +107,8 @@
     },
     "dapp": {
         "masterrequired": true,
-        "masterpassword": "Bdp2EtpCzLvj",
+        "masterpassword": "",
         "autoexec": []
     },
     "nethash": "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"
 }
-


### PR DESCRIPTION
- Update `config.json` for Lisk
- Skip exchange if not enabled during `candles:build` task
- Remove `force` param for `grunt` - allow travis to fail on errors
- Adjust candles to modifications in Poloniex API
- Improve candles performance - get trades once, then generate candles for all periods
- Allow dynamic timeframe for build candles for Poloniex

Closes https://github.com/LiskHQ/lisk-explorer/issues/167
Closes https://github.com/LiskHQ/lisk-explorer/issues/175