### PR TITLE
Search performance improvement - Closes #320

### DIFF
--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -3,6 +3,9 @@ module.exports = function (app, api) {
 		return { version: app.get('version') };
 	};
 	const exchange = app.exchange;
+	const addressReg = /^[0-9]{2,21}[L|l]$/g;
+	const publicKeyReg = /^[0-9a-f]{64}$/g;
+	const usernameReg = /[a-z!@$&_.]/g;
 
 	const searchDelegates = function (id, error, success) {
 		const delegates = new api.delegates(app);
@@ -47,7 +50,7 @@ module.exports = function (app, api) {
 		const transactions = new api.transactions(app);
 		transactions.getTransaction(
 			id,
-			() => searchPublicKey(id, error, success),
+			() => searchDelegates(id, error, success),
 			(body) => {
 				if (body.success === true) {
 					return success({ success: true, type: 'tx', id: body.transaction.id });
@@ -95,6 +98,12 @@ module.exports = function (app, api) {
 	this.search = function (id, error, success) {
 		if (id === null) {
 			return error({ success: false, error: 'Missing/Invalid search criteria' });
+		} else if (addressReg.test(id)) {
+			return searchAccount(id, error, success);
+		} else if (publicKeyReg.test(id)) {
+			return searchPublicKey(id, error, success);
+		} else if (usernameReg.test(id)) {
+			return searchDelegates(id, error, success);
 		}
 		return searchHeight(id, error, success);
 	};


### PR DESCRIPTION
**What we currently have:**
We are making Api calls in this sequence:
`searchHeight`, `searchBlock`, `searchTransaction`, `searchPublicKey`, `searchAccount`, `searchDelegates`
Meaning that to get the results of a search for delegate username, we had to make 6 Api calls.

**What I do here:**
I use the following regex statements
 - `/^[0-9]{2,21}[L|l]$/g` for address
 - `/^[0-9a-f]{64}$/g` for publicKey
 - `/[a-z!@$&_.]/g` which covers pretty much all the delegates
and if all these cases fails, it will make these requests:
`searchHeight`, `searchBlock`, `searchTransaction`, `searchDelegates`.

Since it's possible to choose a number as username, I've put `searchDelegate` here, but since practically all the existing usernames include at least one character, I've put the `searchDelegate` last Api call, so it's less likely to be called.

Closes #320 