### PR TITLE
Consistent api params - Closes #360

### DIFF
--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -224,7 +224,7 @@ module.exports = function (app) {
 			});
 	};
 
-	this.getBlockStatus = function (error, success) {
+	this.getBlockStatus = function (query, error, success) {
 		request.get({
 			url: `${app.get('lisk address')}/api/blocks/getStatus`,
 			json: true,

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -85,7 +85,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	this.getPriceTicker = function (error, success) {
+	this.getPriceTicker = function (query, error, success) {
 		if (app.get('exchange enabled')) {
 			// If exchange rates are enabled - that endpoint cannot fail,
 			// in worst case we return empty object here

--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -45,7 +45,7 @@ module.exports = function (app) {
 		};
 	}
 
-	this.getActive = function (error, success) {
+	this.getActive = function (query, error, success) {
 		const delegates = new Active();
 
 		async.waterfall([
@@ -146,7 +146,7 @@ module.exports = function (app) {
 		};
 	}
 
-	this.getLatestRegistrations = function (error, success) {
+	this.getLatestRegistrations = function (query, error, success) {
 		const registrations = new Registrations();
 
 		async.waterfall([
@@ -204,7 +204,7 @@ module.exports = function (app) {
 		};
 	}
 
-	this.getLatestVotes = function (error, success) {
+	this.getLatestVotes = function (query, error, success) {
 		const votes = new Votes();
 
 		async.waterfall([
@@ -224,7 +224,7 @@ module.exports = function (app) {
 		});
 	};
 
-	this.getNextForgers = function (error, success) {
+	this.getNextForgers = function (query, error, success) {
 		request.get({
 			url: `${app.get('lisk address')}/api/delegates/getNextForgers?limit=101`,
 			json: true,
@@ -320,7 +320,7 @@ module.exports = function (app) {
 		};
 	}
 
-	this.getLastBlock = function (error, success) {
+	this.getLastBlock = function (query, error, success) {
 		const lastBlock = new LastBlock();
 
 		async.waterfall([

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -68,7 +68,7 @@ module.exports = function (app) {
 		};
 	}
 
-	this.getBlocks = function (error, success) {
+	this.getBlocks = function (query, error, success) {
 		let offset = 0;
 		const limit = 100;
 		const blocks = new Blocks();
@@ -105,7 +105,7 @@ module.exports = function (app) {
 			});
 	};
 
-	this.getLastBlock = function (error, success) {
+	this.getLastBlock = function (query, error, success) {
 		const blocks = new Blocks();
 
 		request.get({
@@ -300,7 +300,7 @@ module.exports = function (app) {
 		/* eslint-enable consistent-return */
 	}
 
-	this.getPeers = function (error, success) {
+	this.getPeers = function (query, error, success) {
 		let offset = 0;
 		const limit = 100;
 		const peers = new Peers(this.locator);

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -294,7 +294,7 @@ module.exports = function (app) {
 		this.getTransaction(transactionId, error, success, '/api/transactions/unconfirmed/get?id=');
 	};
 
-	this.getUnconfirmedTransactions = function (error, success, transactions) {
+	this.getUnconfirmedTransactions = function (transactions, error, success) {
 		async.waterfall([
 			cb => request.get({
 				url: `${app.get('lisk address')}/api/transactions/unconfirmed`,
@@ -317,7 +317,7 @@ module.exports = function (app) {
 		});
 	};
 
-	this.getLastTransactions = function (error, success) {
+	this.getLastTransactions = function (query, error, success) {
 		request.get({
 			url: `${app.get('lisk address')}/api/transactions?orderBy=timestamp:desc&limit=20`,
 			json: true,
@@ -326,7 +326,7 @@ module.exports = function (app) {
 				return error({ success: false, error: (err || 'Response was unsuccessful') });
 			} else if (body.success === true) {
 				_.each(body.transactions, knowledge.inTx);
-				return this.getUnconfirmedTransactions(error, success, body.transactions);
+				return this.getUnconfirmedTransactions(body.transactions, error, success);
 			}
 			return error({ success: false, error: body.error });
 		});

--- a/sockets/activityGraph.js
+++ b/sockets/activityGraph.js
@@ -39,6 +39,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getLastBlock = true;
 		return statistics.getLastBlock(
+			'preserved',
 			() => {
 				running.getLastBlock = false;
 				cb('LastBlock');

--- a/sockets/delegateMonitor.js
+++ b/sockets/delegateMonitor.js
@@ -45,6 +45,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getActive = true;
 		return delegates.getActive(
+			'preserved',
 			() => { running.getActive = false; cb('Active'); },
 			(res) => { running.getActive = false; cb(null, res); });
 	};
@@ -76,6 +77,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getLastBlock = true;
 		return delegates.getLastBlock(
+			'preserved',
 			() => {
 				running.getLastBlock = false;
 				cb('LastBlock');
@@ -92,6 +94,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getRegistrations = true;
 		return delegates.getLatestRegistrations(
+			'preserved',
 			() => {
 				running.getRegistrations = false;
 				cb('Registrations');
@@ -108,6 +111,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getVotes = true;
 		return delegates.getLatestVotes(
+			'preserved',
 			() => {
 				running.getVotes = false;
 				cb('Votes');
@@ -124,6 +128,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getNextForgers = true;
 		return delegates.getNextForgers(
+			'preserved',
 			() => {
 				running.getNextForgers = false;
 				cb('NextForgers');

--- a/sockets/header.js
+++ b/sockets/header.js
@@ -36,6 +36,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getBlockStatus = true;
 		return blocks.getBlockStatus(
+			'preserved',
 			() => { running.getBlockStatus = false; cb('Status'); },
 			(res) => { running.getBlockStatus = false; cb(null, res); });
 	};
@@ -46,6 +47,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getPriceTicker = true;
 		return common.getPriceTicker(
+			'preserved',
 			() => { running.getPriceTicker = false; cb('PriceTicker'); },
 			(res) => { running.getPriceTicker = false; cb(null, res); });
 	};

--- a/sockets/networkMonitor.js
+++ b/sockets/networkMonitor.js
@@ -32,6 +32,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getLastBlock = true;
 		return statistics.getLastBlock(
+			'preserved',
 			() => {
 				running.getLastBlock = false;
 				cb('LastBlock');
@@ -48,6 +49,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getBlocks = true;
 		return statistics.getBlocks(
+			'preserved',
 			() => {
 				running.getBlocks = false;
 				cb('Blocks');
@@ -64,6 +66,7 @@ module.exports = function (app, connectionHandler, socket) {
 		}
 		running.getPeers = true;
 		return statistics.getPeers(
+			'preserved',
 			() => {
 				running.getPeers = false;
 				cb('Peers');


### PR DESCRIPTION
### What was the problem?
We had inconsistent Api definitions, some had:
 `Service.method = (error, success) => {}`
and some had:
`Service.method = (param, error, success) => {}`
and some had:
`Service.method = (error, success, param) => {}`

and this caused confusion when trying to used different Apis in different places.

### How did I fix it?
I used 
`Service.method = (param, error, success) => {}`
everywhere, and where ever the Api didn't need a parameter, I passed `'preserved'` to maintain the sequence of parameters.

### How to test it?
Check if there's no regressions in term of the data returned to all the pages.

### Review checklist
- The PR solves #360 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
