### PR TITLE
Flag uninitialized addresses - Closes #372

### DIFF
--- a/src/components/address/address.html
+++ b/src/components/address/address.html
@@ -47,11 +47,14 @@
 								<span>{{vm.address.address}}&nbsp;<span class="btn-copy" clip-copy="vm.address.address"></span></span>
 							</td>
 						</tr>
-						<tr class="hidden-xs" data-ng-if="vm.address.publicKey">
+						<tr class="hidden-xs">
 							<td><strong>Public Key</strong></td>
-							<td class="text-right">
+							<td class="text-right" data-ng-if="vm.address.publicKey">
 								{{vm.address.publicKey}}&nbsp;
 								<span class="btn-copy" clip-copy="vm.address.publicKey"></span>
+							</td>
+							<td class="text-right" data-ng-if="!vm.address.publicKey">
+								<span>Not initialized</span>
 							</td>
 						</tr>
 						<tr>

--- a/src/components/market-watcher/market-watcher.service.js
+++ b/src/components/market-watcher/market-watcher.service.js
@@ -49,6 +49,7 @@ const MarketWatcher = function ($q, $http, $rootScope, vm) {
 			if (result.data.success) {
 				vm.exchangeLogos = {};
 				vm.exchanges = Object.keys(result.data.exchanges).filter((key) => {
+					// eslint-disable-next-line no-undef
 					System.import(`../../assets/img/exchanges/${key}.png`).then((value) => {
 						vm.exchangeLogos[key] = value;
 					});


### PR DESCRIPTION
### What was the problem?
For uninitialised address (Addresses with no public key registered) we don't show the publicKey info, which can be confusing.

### How did I fix it?
Instead of removing the whole row, I mark as `Not initialized`.

### How to test it?
Navigate to [16703865346049622043L](https://testnet-explorer.lisk.io/address/16703865346049622043L) in testnet

### Review checklist
- The PR solves #372 
- All new code follows best practices