### PR TITLE
Fix market watcher candles endpoints - Closes #368

### DIFF
--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -13,6 +13,7 @@ function AbstractCandles(client) {
 	this.start = null;
 	this.end = null;
 	this.last = null;
+	this.client = client;
 
 	this.response = {
 		error: 'message',
@@ -33,33 +34,38 @@ function AbstractCandles(client) {
 		let found = false;
 		let results = [];
 
-		logger.info('Candles:', 'Retrieving trades from', `${self.name}...`);
+		logger.info(`Candles: Retrieving trades from ${self.name}...`);
 
 		async.doUntil(
 			(next) => {
 				logger.info(`Candles: Start: ${start ? new Date(start * 1000).toISOString() : 'N/A'} End: ${end ? new Date(end * 1000).toISOString() : 'N/A'}`);
-
 				request.get({
-					url: self.url + (start ? `&start=${start}` : '') + (end ? `&end=${end}` : ''),
-					json: true,
+					url: self.url + (start ? `&start=${start}` : '') + (end ? `&end=${end}` : '')
 				}, (err, resp, body) => {
 					if (err || resp.statusCode !== 200) {
 						return next(err || 'Response was unsuccessful');
 					}
 
-					const message = body[self.response.error];
+					let json;
+					try {
+						json = JSON.parse(body);
+					} catch (jsonError) {
+						logger.error(`Error while parsing JSON: ${jsonError.message}`);
+					}
+
+					const message = json[self.response.error];
 					if (message) {
 						return next(message);
 					}
 
-					const data = self.rejectTrades(body[self.response.data] || body);
+					const data = self.rejectTrades(json[self.response.data] || json);
 					if (!self.validData(data)) {
 						logger.error('Candles:', 'Invalid data received');
 						return next();
 					}
 
 					if (self.validTrades(results, data)) {
-						logger.info('Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades');
+						logger.info(['Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades'].join(' '));
 						results = self.acceptTrades(results, data);
 						end = self.nextEnd(data);
 						return next();
@@ -73,7 +79,7 @@ function AbstractCandles(client) {
 				if (err) {
 					return cb(`Error retrieving trades: ${err}`);
 				}
-				logger.info('Candles:', results.length.toString(), 'trades in total retrieved');
+				logger.info(`Candles: ${results.length.toString()} trades in total retrieved`);
 				return cb(null, results);
 			});
 	};
@@ -158,7 +164,7 @@ function AbstractCandles(client) {
 	};
 
 	this.saveCandles = function (results, cb) {
-		const multi = client.multi();
+		const multi = self.client.multi();
 		// to fix eslint
 		const key = self.candleKey();
 
@@ -170,24 +176,24 @@ function AbstractCandles(client) {
 			if (err) {
 				return cb(err);
 			}
-			logger.info('Candles:', replies.length.toString(), 'candles saved');
+			logger.info(`Candles: ${replies.length.toString()} candles saved`);
 			return cb(null, results);
 		});
 	};
 
 	this.restoreCandles = function (duration, index, cb) {
-		client.LRANGE(self.candleKey(duration), index, -1, (err, reply) => {
+		self.client.LRANGE(self.candleKey(duration), index, -1, (err, reply) => {
 			if (err) {
 				return cb(err);
 			}
 			reply = JSON.parse(`[${reply.toString()}]`);
-			logger.info('Candles:', reply.length.toString(), 'candles restored');
+			logger.info(`Candles: ${reply.length.toString()} candles restored`);
 			return cb(null, reply);
 		});
 	};
 
 	const _buildCandles = function (trades, cb) {
-		logger.info('Candles:', 'Building', self.duration, 'candles for', `${self.name}...`);
+		logger.info(`Candles: Building ${self.duration} candles for ${self.name}...`);
 
 		async.waterfall([
 			function (waterCb) {
@@ -217,7 +223,7 @@ function AbstractCandles(client) {
 	};
 
 	const _updateCandles = function (trades, cb) {
-		logger.info('Candles:', 'Updating', self.duration, 'candles for', `${self.name}...`);
+		logger.info(`Candles: Updating ${self.duration} candles for ${self.name}...`);
 
 		async.waterfall([
 			function (waterCb) {
@@ -267,7 +273,7 @@ function AbstractCandles(client) {
 		async.waterfall([
 			function (callback) {
 				self.duration = self.durations[0]; // Reset current duration
-				client.LRANGE(self.candleKey(), -1, -1, (err, reply) => {
+				self.client.LRANGE(self.candleKey(), -1, -1, (err, reply) => {
 					if (err) {
 						return callback(err);
 					} else if (_.size(reply) === 0) {

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -1,12 +1,19 @@
 const AbstractCandles = require('./abstract');
 const util = require('util');
+const _ = require('underscore');
+const async = require('async');
+const request = require('request');
+const moment = require('moment');
+const logger = require('../../utils/logger');
 
 function BittrexCandles(...rest) {
 	AbstractCandles.apply(this, rest);
+	const self = this;
 
 	this.name = 'bittrex';
 	this.key = `${this.name}Candles`;
-	this.url = 'https://bittrex.com/api/v1.1/public/getmarkethistory?market=BTC-LSK&count=50';
+	this.url = 'https://bittrex.com/Api/v2.0/pub/market/GetTicks?marketName=BTC-LSK&tickInterval=fiveMin';
+
 	this.start = '';
 	this.last = null;
 
@@ -16,10 +23,235 @@ function BittrexCandles(...rest) {
 	};
 
 	this.candle = {
-		id: 'Id',
-		date: 'TimeStamp',
-		price: 'Price',
-		amount: 'Quantity',
+		date: 'T',
+		open: 'O',
+		close: 'C',
+		high: 'H',
+		low: 'L',
+		liskVolume: 'V',
+		btcVolume: 'BV',
+		// not provided by API
+		numTrades: null,
+		firstTrade: null,
+		lastTrade: null,
+		nextEnd: null,
+	};
+
+	this.parseCandles = function (results, cb) {
+		const mapping = self.candle;
+
+		let sum = _.map(results, (period) => {
+			const sortedPeriodList = _.sortBy(period, t => self.parseDate(t[mapping.date]).unix());
+			const earliestDateItem = sortedPeriodList[0];
+			const latestDateItem = sortedPeriodList[sortedPeriodList.length - 1];
+
+			return {
+				timestamp: self.parseDate(earliestDateItem[mapping.date]).unix(),
+				date: self.parseDate(earliestDateItem[mapping.date]).toDate(),
+				high: _.max(period, t => parseFloat(t[mapping.high]))[mapping.high],
+				low: _.min(period, t => parseFloat(t[mapping.low]))[mapping.low],
+				open: earliestDateItem[mapping.open],
+				close: latestDateItem[mapping.close],
+				liskVolume: _.reduce(period, (memo, t) =>
+					(memo + parseFloat(t[mapping.liskVolume])), 0.0).toFixed(8),
+				btcVolume: _.reduce(period, (memo, t) =>
+					(memo + (parseFloat(t[mapping.btcVolume]) * parseFloat(t[mapping.high] - t[mapping.low]))), 0.0)
+					.toFixed(8),
+				// firstTrade: _.first(period)[self.candle.id],
+				// lastTrade: _.last(period)[self.candle.id],
+				// nextEnd: self.nextEnd(period),
+				// numTrades: _.size(period),
+			};
+		});
+
+		sum = _.reject(sum, s => s.timestamp >= moment.utc().startOf(self.duration).unix());
+
+		return cb(null, sum);
+	};
+
+	const _buildCandles = function (trades, cb) {
+		logger.info(`Candles: Building ${self.duration} candles for ${self.name}...`);
+
+		async.waterfall([
+			function (waterCb) {
+				self.client.DEL(self.candleKey(), (err) => {
+					if (err) {
+						return waterCb(err);
+					}
+					return waterCb();
+				});
+			},
+			function (waterCb) {
+				return self.groupTrades(trades, waterCb); // Should be groupCandles
+			},
+			function (results, waterCb) {
+				return self.parseCandles(results, waterCb);
+			},
+			function (results, waterCb) {
+				return self.saveCandles(results, waterCb);
+			},
+		],
+		(err, results) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null, results);
+		});
+	};
+
+	this.buildCandles = function (cb) {
+		async.waterfall([
+			function (waterCb) {
+				return self.retrieveTrades(waterCb);
+			},
+			function (trades, waterCb) {
+				async.eachSeries(self.durations, (duration, eachCb) => {
+					self.duration = duration;
+					return _buildCandles(trades, eachCb);
+				}, (err) => {
+					if (err) {
+						return waterCb(err);
+					}
+					return waterCb(null);
+				});
+			},
+		],
+		(err, results) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null, results);
+		});
+	};
+
+	const _updateCandles = function (trades, cb) {
+		logger.info(`Candles: Updating ${self.duration} candles for ${self.name}...`);
+
+		async.waterfall([
+			function (waterCb) {
+				return self.groupTrades(trades, waterCb);
+			},
+			function (results, waterCb) {
+				return self.parseCandles(results, waterCb);
+			},
+			function (results, waterCb) {
+				return self.saveCandles(results, waterCb);
+			},
+		],
+		(err, results) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null, results);
+		});
+	};
+
+	this.updateCandles = function (cb) {
+		async.waterfall([
+			function (callback) {
+				self.duration = self.durations[0]; // Reset current duration
+				self.client.LRANGE(self.candleKey(), -1, -1, (err, reply) => {
+					if (err) {
+						return callback(err);
+					} else if (_.size(reply) === 0) {
+						return callback(`No data was found for: ${self.name}`);
+					}
+					self.last = JSON.parse(reply);
+					return callback(null, self.last);
+				});
+			},
+			function (last, waterCb) {
+				return self.retrieveTrades(waterCb);
+			},
+			function (trades, waterCb) {
+				async.eachSeries(self.durations, (duration, eachCb) => {
+					self.duration = duration;
+					return _updateCandles(trades, eachCb);
+				}, (err) => {
+					if (err) {
+						return waterCb(err);
+					}
+					return waterCb(null);
+				});
+			},
+		],
+		(err) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null);
+		});
+	};
+
+	this.retrieveTrades = function (cb) {	// the name should be retrieveCandles or retrieveData
+		let found = false;
+		let results = [];
+
+		logger.info(`Candles: Retrieving candles from ${self.name}...`);
+
+		async.doUntil(
+			(next) => {
+				request.get({
+					url: self.url,
+				}, (err, resp, body) => {
+					if (err || resp.statusCode !== 200) {
+						return next(err || 'Response was unsuccessful');
+					}
+
+					let json;
+					try {
+						json = JSON.parse(body);
+					} catch (jsonError) {
+						return next(`Error while parsing JSON: ${jsonError.message}`);
+					}
+
+					const message = json[self.response.error];
+					if (message) {
+						return next(message);
+					}
+
+					const data = self.rejectTrades(json[self.response.data] || json);
+					if (!self.validData(data)) {
+						logger.error('Candles:', 'Invalid data received');
+						return next();
+					}
+
+					if (self.validTrades(results, data)) {
+						results = self.acceptTrades(results, data);
+						return next();
+					}
+					found = true;
+					return next();
+				});
+			},
+			() => found,
+			(err) => {
+				if (err) {
+					return cb(`Error retrieving trades: ${err}`);
+				}
+				logger.info(`Candles: ${results.length.toString()} candles retrieved in total`);
+				return cb(null, results);
+			});
+	};
+
+	this.validData = function (data) {
+		if (_.size(data) > 0) {
+			return _.first(data)[self.candle.date];
+		}
+		return true;
+	};
+
+	this.validTrades = function (results, data) {
+		// TODO: check that one
+		const any = _.size(data) > 0;
+
+		if (any && _.size(results) > 0) {
+			const firstLast = _.first(results)[self.candle.id] !== _.last(data)[self.candle.id];
+			const lastFirst = _.last(results)[self.candle.id] !== _.first(data)[self.candle.id];
+
+			return (firstLast && lastFirst);
+		}
+		return any;
 	};
 
 	this.acceptTrades = function (results, data) {


### PR DESCRIPTION
### What was the problem?
The candlestick charts for the Bittrex exchange were not shown correctly. The backend part of the application that is responsible for this was missing the crucial data, that were not able to be gathered from the original data source - Bittrex API version 1.1.

### How did I fix it?
I switched to the version 2.0 of the Bittrex exchange API.
The new data provided by the API are candlestick data itself, with an interval of 5 mins.
Other charts, such as hour and day charts are generated from the same data source.

I've copied a lot of the original code from the ``abstract.js`` file. Most of the code was reused, excluding the grouping part - these functions are performing different operations, based on the data provided in the version 2.0 of Bittrex API.

There is also significant overuse of the Underscore library - I've mentioned it in the issue #375.

### How to test it?
Use Market Watcher to determine whether the candlesticks are rendered correctly.

### Review checklist
- The PR solves #368 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
