### PR TITLE
Messages are written to the log properly - Closes #376

### DIFF
--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -33,7 +33,7 @@ function AbstractCandles(client) {
 		let found = false;
 		let results = [];
 
-		logger.info('Candles:', 'Retrieving trades from', `${self.name}...`);
+		logger.info(`Candles: Retrieving trades from ${self.name}...`);
 
 		async.doUntil(
 			(next) => {
@@ -59,7 +59,7 @@ function AbstractCandles(client) {
 					}
 
 					if (self.validTrades(results, data)) {
-						logger.info('Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades');
+						logger.info(['Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades'].join(' '));
 						results = self.acceptTrades(results, data);
 						end = self.nextEnd(data);
 						return next();
@@ -73,7 +73,7 @@ function AbstractCandles(client) {
 				if (err) {
 					return cb(`Error retrieving trades: ${err}`);
 				}
-				logger.info('Candles:', results.length.toString(), 'trades in total retrieved');
+				logger.info(`Candles: ${results.length.toString()} trades in total retrieved`);
 				return cb(null, results);
 			});
 	};
@@ -170,7 +170,7 @@ function AbstractCandles(client) {
 			if (err) {
 				return cb(err);
 			}
-			logger.info('Candles:', replies.length.toString(), 'candles saved');
+			logger.info(`Candles: ${replies.length.toString()} candles saved`);
 			return cb(null, results);
 		});
 	};
@@ -181,13 +181,13 @@ function AbstractCandles(client) {
 				return cb(err);
 			}
 			reply = JSON.parse(`[${reply.toString()}]`);
-			logger.info('Candles:', reply.length.toString(), 'candles restored');
+			logger.info(`Candles: ${reply.length.toString()} candles restored`);
 			return cb(null, reply);
 		});
 	};
 
 	const _buildCandles = function (trades, cb) {
-		logger.info('Candles:', 'Building', self.duration, 'candles for', `${self.name}...`);
+		logger.info(`Candles: Building ${self.duration} candles for ${self.name}...`);
 
 		async.waterfall([
 			function (waterCb) {
@@ -217,7 +217,7 @@ function AbstractCandles(client) {
 	};
 
 	const _updateCandles = function (trades, cb) {
-		logger.info('Candles:', 'Updating', self.duration, 'candles for', `${self.name}...`);
+		logger.info(`Candles: Updating ${self.duration} candles for ${self.name}...`);
 
 		async.waterfall([
 			function (waterCb) {


### PR DESCRIPTION
### What was the problem?
Log messages are cut, only the first part of the message is visible.

### How did I fix it?
I've changed ``logger(a, b, c)`` notation to ES6-compliant: ``logger(`{$a} ${b} ${c}`)``.

### How to test it?
Run the application and compare log file with messages in the code.
The tests are running properly only when changes from #368 are merged.

### Review checklist
- The PR solves #376 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
