### PR TITLE
getStatistics returns error response instead of raising an exception when no data available in Redis - Closes #377

### DIFF
--- a/lib/api/candles.js
+++ b/lib/api/candles.js
@@ -118,7 +118,7 @@ module.exports = function (app) {
 			},
 		],
 		(err, results) => {
-			if (err) {
+			if (err || !results[0] || !results[1]) {
 				return error({ success: false });
 			}
 			let statistics = {


### PR DESCRIPTION
### What was the problem?
When data from Redis were not accessible, the application raised an unhandled exception and closed 

### How did I fix it?
I've added additional checks, ensuring that the data are already there.

### How to test it?
``redis-cli -p 6380 --raw FLUSHALL``
Run the process on empty Redis database with enabled Market Watcher.
The process should not be stopped.

### Review checklist
- The PR solves #377
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
