### PR TITLE
Fix market watcher candles endpoints - Closes #368

### DIFF
--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -38,7 +38,6 @@ function AbstractCandles(client) {
 		async.doUntil(
 			(next) => {
 				logger.info(`Candles: Start: ${start ? new Date(start * 1000).toISOString() : 'N/A'} End: ${end ? new Date(end * 1000).toISOString() : 'N/A'}`);
-
 				request.get({
 					url: self.url + (start ? `&start=${start}` : '') + (end ? `&end=${end}` : ''),
 					json: true,
@@ -47,12 +46,23 @@ function AbstractCandles(client) {
 						return next(err || 'Response was unsuccessful');
 					}
 
+					let parsedBody;
+					if (typeof parsedBody === 'string') {
+						try {
+							parsedBody = JSON.parse(body);
+						} catch (jsonError) {
+							return next(`Error while parsing JSON: ${jsonError.message}`);
+						}
+					} else {
+						parsedBody = body;
+					}
+
 					const message = body[self.response.error];
 					if (message) {
 						return next(message);
 					}
 
-					const data = self.rejectTrades(body[self.response.data] || body);
+					const data = self.rejectTrades(parsedBody[self.response.data] || parsedBody);
 					if (!self.validData(data)) {
 						logger.error('Candles:', 'Invalid data received');
 						return next();
@@ -92,7 +102,7 @@ function AbstractCandles(client) {
 
 	this.validData = function (data) {
 		if (_.size(data) > 0) {
-			return _.first(data)[self.candle.id];
+			return _.first(data)[self.validationKey];
 		}
 		return true;
 	};
@@ -127,23 +137,7 @@ function AbstractCandles(client) {
 	};
 
 	this.sumTrades = function (results, cb) {
-		let sum = _.map(results, period => ({
-			timestamp: self.parseDate(period[0][self.candle.date]).unix(),
-			date: self.parseDate(period[0][self.candle.date]).toDate(),
-			high: _.max(period, t => parseFloat(t[self.candle.price]))[self.candle.price],
-			low: _.min(period, t => parseFloat(t[self.candle.price]))[self.candle.price],
-			open: _.first(period)[self.candle.price],
-			close: _.last(period)[self.candle.price],
-			liskVolume: _.reduce(period, (memo, t) =>
-				(memo + parseFloat(t[self.candle.amount])), 0.0).toFixed(8),
-			btcVolume: _.reduce(period, (memo, t) =>
-				(memo + (parseFloat(t[self.candle.amount]) * parseFloat(t[self.candle.price]))), 0.0)
-				.toFixed(8),
-			firstTrade: _.first(period)[self.candle.id],
-			lastTrade: _.last(period)[self.candle.id],
-			nextEnd: self.nextEnd(period),
-			numTrades: _.size(period),
-		}));
+		let sum = _.map(results, period => this.parser.call(this, period));
 
 		sum = _.reject(sum, s => s.timestamp >= moment.utc().startOf(self.duration).unix());
 

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -6,7 +6,7 @@ function BittrexCandles(...rest) {
 
 	this.name = 'bittrex';
 	this.key = `${this.name}Candles`;
-	this.url = 'https://bittrex.com/api/v1.1/public/getmarkethistory?market=BTC-LSK&count=50';
+	this.url = 'https://bittrex.com/Api/v2.0/pub/market/GetTicks?marketName=BTC-LSK&tickInterval=fiveMin';
 	this.start = '';
 	this.last = null;
 

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -1,5 +1,6 @@
 const AbstractCandles = require('./abstract');
 const util = require('util');
+const _ = require('underscore');
 
 function BittrexCandles(...rest) {
 	AbstractCandles.apply(this, rest);
@@ -16,10 +17,36 @@ function BittrexCandles(...rest) {
 	};
 
 	this.candle = {
-		id: 'Id',
-		date: 'TimeStamp',
-		price: 'Price',
-		amount: 'Quantity',
+		date: 'T',
+		open: 'O',
+		close: 'C',
+		high: 'H',
+		low: 'L',
+		liskVolume: 'V',
+		btcVolume: 'BV',
+	};
+
+	this.validationKey = 'T';
+
+	this.parser = function (period) {
+		const sortedPeriodList = _.sortBy(period, t => self.parseDate(t[this.candle.date]).unix());
+		const earliestDateItem = sortedPeriodList[0];
+		const latestDateItem = sortedPeriodList[sortedPeriodList.length - 1];
+
+		return {
+			timestamp: this.parseDate(earliestDateItem[this.candle.date]).unix(),
+			date: this.parseDate(earliestDateItem[this.candle.date]).toDate(),
+			high: _.max(period, t => parseFloat(t[this.candle.high]))[this.candle.high],
+			low: _.min(period, t => parseFloat(t[this.candle.low]))[this.candle.low],
+			open: earliestDateItem[this.candle.open],
+			close: latestDateItem[this.candle.close],
+			liskVolume: _.reduce(period, (memo, t) =>
+				(memo + parseFloat(t[this.candle.liskVolume])), 0.0).toFixed(8),
+			btcVolume: _.reduce(period, (memo, t) =>
+				(memo + (parseFloat(t[this.candle.btcVolume]) *
+				parseFloat(t[this.candle.high] - t[this.candle.low]))), 0.0)
+				.toFixed(8),
+		};
 	};
 
 	this.acceptTrades = function (results, data) {

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -29,7 +29,7 @@ function BittrexCandles(...rest) {
 	this.validationKey = 'T';
 
 	this.parser = function (period) {
-		const sortedPeriodList = _.sortBy(period, t => self.parseDate(t[this.candle.date]).unix());
+		const sortedPeriodList = _.sortBy(period, t => this.parseDate(t[this.candle.date]).unix());
 		const earliestDateItem = sortedPeriodList[0];
 		const latestDateItem = sortedPeriodList[sortedPeriodList.length - 1];
 

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -26,6 +26,28 @@ function PoloniexCandles(client, params, ...rest) {
 		amount: 'amount',
 	};
 
+	this.validationKey = 'tradeID';
+
+	this.parser = function (period) {
+		return {
+			timestamp: this.parseDate(period[0][this.candle.date]).unix(),
+			date: this.parseDate(period[0][this.candle.date]).toDate(),
+			high: _.max(period, t => parseFloat(t[this.candle.price]))[this.candle.price],
+			low: _.min(period, t => parseFloat(t[this.candle.price]))[this.candle.price],
+			open: _.first(period)[this.candle.price],
+			close: _.last(period)[this.candle.price],
+			liskVolume: _.reduce(period, (memo, t) =>
+				(memo + parseFloat(t[this.candle.amount])), 0.0).toFixed(8),
+			btcVolume: _.reduce(period, (memo, t) =>
+				(memo + (parseFloat(t[this.candle.amount]) * parseFloat(t[this.candle.price]))), 0.0)
+				.toFixed(8),
+			firstTrade: _.first(period)[this.candle.id],
+			lastTrade: _.last(period)[this.candle.id],
+			nextEnd: this.nextEnd(period),
+			numTrades: _.size(period),
+		};
+	};
+
 	this.nextEnd = function (data) {
 		return moment(_.first(data).date).subtract(1, 's').unix();
 	};

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -3,10 +3,11 @@ const moment = require('moment');
 const _ = require('underscore');
 const util = require('util');
 
-function PoloniexCandles(client, params, ...rest) {
-	AbstractCandles.apply(this, [client, params, ...rest]);
+function PoloniexCandles(...rest) {
+	AbstractCandles.apply(this, rest);
 
 	const now = Math.floor(Date.now() / 1000);
+	const params = rest[1];
 	this.start = params && params.buildTimeframe ? (now - params.buildTimeframe) : null;
 	this.end = now; // Current unix timestamp (in sec)
 

--- a/test/api/exchanges.js
+++ b/test/api/exchanges.js
@@ -17,7 +17,7 @@ describe('Exchanges API (Market Watcher)', () => {
 	function checkCandles(id) {
 		for (let i = 0; i < id.length; i++) {
 			if (id[i + 1]) {
-				node.expect(id[i]).to.have.all.keys(
+				node.expect(id[i]).to.contain.all.keys(
 					'timestamp',
 					'date',
 					'high',
@@ -25,11 +25,7 @@ describe('Exchanges API (Market Watcher)', () => {
 					'open',
 					'close',
 					'liskVolume',
-					'btcVolume',
-					'firstTrade',
-					'lastTrade',
-					'nextEnd',
-					'numTrades');
+					'btcVolume');
 			}
 		}
 	}


### PR DESCRIPTION
## What was the problem?
The candlestick charts for the Bittrex exchange were not shown correctly. The backend part of the application that is responsible for this was missing the crucial data, that were not able to be gathered from the original data source - Bittrex API version 1.1.

## How did I fix it?
I switched to the version 2.0 of the Bittrex exchange API.
The new data provided by the API are candlestick data itself, with an interval of 5 mins.
Other charts, such as hour and day charts are generated from the same data source.

I've copied a lot of the original code from the abstract.js file. Most of the code was reused, excluding the grouping part - these functions are performing different operations, based on the data provided in the version 2.0 of Bittrex API.

There is also significant overuse of the Underscore library - I've mentioned it in the issue #375.

## How to test it?
Use Market Watcher to determine whether the candlesticks are rendered correctly.

## Review checklist
- [x] The PR solves #368
- All new code is covered with unit tests
- All new features are covered with e2e tests
- [x] All new code follows best practices