### PR TITLE
Number of trades placeholder when data unavailable - Closes #387

### DIFF
--- a/src/components/market-watcher/market-watcher.html
+++ b/src/components/market-watcher/market-watcher.html
@@ -100,7 +100,8 @@
 							<div class="pull-left num-trades">
 								<p class="small-title">Num Trades</p>
 								<p class="big-details">
-									<span class="num-trades">{{vm.statistics.numTrades}}</span>
+									<span ng-if="vm.statistics.numTrades" class="num-trades">{{vm.statistics.numTrades}}</span>
+									<span ng-if="!vm.statistics.numTrades" class="num-trades">n&#47;a</span>
 								</p>
 							</div>
 						</div>

--- a/src/components/market-watcher/market-watcher.html
+++ b/src/components/market-watcher/market-watcher.html
@@ -101,7 +101,7 @@
 								<p class="small-title">Num Trades</p>
 								<p class="big-details">
 									<span ng-if="vm.statistics.numTrades" class="num-trades">{{vm.statistics.numTrades}}</span>
-									<span ng-if="!vm.statistics.numTrades" class="num-trades">n&#47;a</span>
+									<span ng-if="!vm.statistics.numTrades" class="num-trades">N&#47;A</span>
 								</p>
 							</div>
 						</div>


### PR DESCRIPTION
### What was the problem?
Described in #387 

### How did I fix it?
I've modified a template, so the data are displayed when available (for Poloniex), but for Bittrex there is only displayed "n/a".

### How to test it?
Run the app with candles rebuilt (``grunt candles:build``). The data should be present in the num trades field or the "n/a" is visible.

### Review checklist
- The PR solves #387 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
