### PR TITLE
Redis cache TTL bug fix, reduces DB save to one request - Closes #412

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,17 +166,12 @@ app.use((req, res, next) => {
 	if (cache.cacheIgnoreList.indexOf(req.originalUrl) >= 0) {
 		return res.json(req.json);
 	}
-	req.redis.set(req.originalUrl, JSON.stringify(req.json), (err) => {
+
+	const ttl = cache.cacheTTLOverride[req.originalUrl] || config.cacheTTL;
+
+	req.redis.setex(req.originalUrl, ttl, JSON.stringify(req.json), (err) => {
 		if (err) {
 			logger.info(err);
-		} else {
-			const ttl = cache.cacheTTLOverride[req.originalUrl] || config.cacheTTL;
-
-			req.redis.send_command('EXPIRE', [req.originalUrl, ttl], (expErr) => {
-				if (expErr) {
-					logger.info(expErr);
-				}
-			});
 		}
 	});
 


### PR DESCRIPTION
### What was the problem?
Redis cache TTL was not set, which results in TTL = inifinte.

### How did I fix it?
I've rewritten the redis SET command wrapper.
Previous solution required two Redis request, the current one - only one.

### How to test it?
TTL = 20 s, ex. the market watcher data should be refreshed.

### Review checklist
- The PR solves #412
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
