### PR TITLE
Docker deployment fix - Closes #411

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,7 @@ USER lisk
 RUN cd /home/lisk/lisk-explorer && \
     npm install
 RUN cd /home/lisk/lisk-explorer && \
-    npm run build && \
-    redis-server --daemonize yes && \
-    grunt candles:build && \
-    grunt candles:update
+    npm run build
 
 
 FROM node:6-alpine

--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ npm install
  `SERVICE_NAME='your service name' CLIENT_ID='you client id' npm run build`
 
 
+## Post-deployment actions
 
 #### Market Watcher
  Candlestick data needs to be initialized prior to starting Lisk Explorer. During runtime candlestick data is updated automatically.
+
+This step writes data to the local Redis instance. Make sure that your application is already deployed and has access to the production Redis database. 
 
 To build candlestick data for each exchange run:
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ npm install
  
  `SERVICE_NAME='your service name' CLIENT_ID='you client id' npm run build`
 
-
-## Post-deployment actions
+## Post-deployment Actions
 
 #### Market Watcher
  Candlestick data needs to be initialized prior to starting Lisk Explorer. During runtime candlestick data is updated automatically.


### PR DESCRIPTION
### What was the problem?
The market watcher candlestick data needs to be build on the target server, not a build server.

### How did I fix it?
The docker deployment procedure skips the candlestick data build from now on.
Also, updates to the lisk-ansible project have to be done accordingly.

### How to test it?
1. Deploy a docker container with the lisk-explorer.
2. Check if the candlesticks are shown correctly.

### Review checklist
- The PR solves #411 
- All new code follows best practices
