### PR TITLE
Redis cache fix for Bittrex - Closes #416

### DIFF
--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -200,12 +200,7 @@ function AbstractCandles(client) {
 
 		async.waterfall([
 			function (waterCb) {
-				client.DEL(self.candleKey(), (err) => {
-					if (err) {
-						return waterCb(err);
-					}
-					return waterCb();
-				});
+				return self.dropCandles(waterCb);
 			},
 			function (waterCb) {
 				return self.groupTrades(trades, waterCb);
@@ -244,6 +239,15 @@ function AbstractCandles(client) {
 				return cb(err);
 			}
 			return cb(null, results);
+		});
+	};
+
+	this.dropCandles = function (cb) {
+		client.DEL(self.candleKey(), (err) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null);
 		});
 	};
 

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -16,9 +16,13 @@
 const AbstractCandles = require('./abstract');
 const util = require('util');
 const _ = require('underscore');
+const async = require('async');
+const logger = require('../../utils/logger');
 
 function BittrexCandles(...rest) {
 	AbstractCandles.apply(this, rest);
+
+	const self = this;
 
 	this.name = 'bittrex';
 	this.key = `${this.name}Candles`;
@@ -66,6 +70,70 @@ function BittrexCandles(...rest) {
 
 	this.acceptTrades = function (results, data) {
 		return results.concat(data.reverse());
+	};
+
+	const _dropAndSave = function (trades, cb) {
+		async.waterfall([
+			function (waterCb) {
+				return self.dropCandles(waterCb);
+			},
+			function (waterCb) {
+				return self.saveCandles(trades, waterCb);
+			},
+		],
+		(err, results) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null, results);
+		});
+	};
+
+	const _updateCandles = function (trades, cb) {
+		logger.info(`Candles: Updating ${self.duration} candles for ${self.name}...`);
+
+		async.waterfall([
+			function (waterCb) {
+				return self.groupTrades(trades, waterCb);
+			},
+			function (results, waterCb) {
+				return self.sumTrades(results, waterCb);
+			},
+			function (results, waterCb) {
+				return _dropAndSave(results, waterCb);
+			},
+		],
+		(err, results) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null, results);
+		});
+	};
+
+	this.updateCandles = function (cb) {
+		async.waterfall([
+			function (waterCb) {
+				return self.retrieveTrades(null, null, waterCb);
+			},
+			function (trades, waterCb) {
+				async.eachSeries(self.durations, (duration, eachCb) => {
+					self.duration = duration;
+					return _updateCandles(trades, eachCb);
+				}, (err) => {
+					if (err) {
+						return waterCb(err);
+					}
+					return waterCb(null);
+				});
+			},
+		],
+		(err) => {
+			if (err) {
+				return cb(err);
+			}
+			return cb(null);
+		});
 	};
 }
 


### PR DESCRIPTION
### What was the problem?
Candlestick data is stored in Redis. The Old Bittrex API allowed to get partial updates and append them to current dataset. The new API provides all data at once in the candlestick format. That caused the data being appended to the old list and there was no way to distinguish already available objects from new ones. In effect, there were multiple copies of identical objects.  

### How did I fix it?
Current implementation contains custom update method for Bittrex API. The old data are always removed before the new data is stored in Redis.

### How to test it?
Make sure that:
1. The candlestick view looks ok.
2. The server memory usage is not exceeded. 

### Review checklist
- The PR solves #416
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
