### PR TITLE
Bittrex BTC volume bug - Closes #420

### DIFF
--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -62,8 +62,7 @@ function BittrexCandles(...rest) {
 			liskVolume: _.reduce(period, (memo, t) =>
 				(memo + parseFloat(t[this.candle.liskVolume])), 0.0).toFixed(8),
 			btcVolume: _.reduce(period, (memo, t) =>
-				(memo + (parseFloat(t[this.candle.btcVolume]) *
-				parseFloat(t[this.candle.high] - t[this.candle.low]))), 0.0)
+				(memo + (parseFloat(t[this.candle.btcVolume]))), 0.0)
 				.toFixed(8),
 		};
 	};


### PR DESCRIPTION
### What was the problem?
There was a problem with BTC volume for Bittrex exchange displayed in the statistics section.

### How did I fix it?
I've updated the function responsible for BTC Volume count. 

### How to test it?
Market Watcher -> Bittrex tab

### Review checklist
- The PR solves #420
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
