### PR TITLE
Missing delegate data WebSocket fix - Closes #446

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -156,6 +156,9 @@ module.exports = function (app) {
 				} else if (body.success === true) {
 					tx.delegate = body.delegate;
 					return cb();
+				} else if (body.error && body.error === 'Delegate not found') {
+					tx.delegate = {};
+					return cb();
 				}
 				return cb(body.error);
 			});


### PR DESCRIPTION
### What was the problem?
Due to lisk-core error, some data about delegates cannot be found by the lisk-core api.
That breaks the whole procedure of getting data, which results in missing data in the Delegate Monitor.

### How did I fix it?
I've added one check that makes the whole procedure proceed even if some delegate data are missing.

### How to test it?
The problem occurs only when lisk-core is running with the specific set of data.
There is a Postgres dump available that includes missing delegates.

### Review checklist
- The PR solves #446 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
