### PR TITLE
Display connected peers count correctly - Closes #445

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -328,7 +328,9 @@ module.exports = function (app) {
 				request.get({
 					url: app.get('lisk address') + peers.url(offset, limit),
 					json: true,
-				}, (err, resp, body) => {
+				},
+				/* eslint-disable consistent-return */
+				(err, resp, body) => {
 					if (err || resp.statusCode !== 200) {
 						return next(err || 'Response was unsuccessful');
 					}

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -241,7 +241,7 @@ module.exports = function (app) {
 			return { name, group };
 		};
 
-		this.collect = function (peers) {
+		this.collect = function (peers, cb) {
 			let i = 0;
 			const self = this;
 
@@ -259,9 +259,10 @@ module.exports = function (app) {
 				(err) => {
 					if (err) {
 						logger.error(`Error collecting peers: ${err}`);
-						return [];
+						cb([]);
+					} else {
+						cb(peers);
 					}
-					return peers;
 				});
 		};
 
@@ -323,6 +324,7 @@ module.exports = function (app) {
 
 		async.doUntil(
 			(next) => {
+				logger.debug(`Requesting ${app.get('lisk address') + peers.url(offset, limit)}`);
 				request.get({
 					url: app.get('lisk address') + peers.url(offset, limit),
 					json: true,
@@ -332,12 +334,11 @@ module.exports = function (app) {
 					}
 
 					if (_.size(body.peers) > 0) {
-						peers.collect(body.peers);
+						peers.collect(body.peers, () => { next(); });
 					} else {
 						found = true;
+						return next();
 					}
-
-					return next();
 				});
 			},
 			() => {

--- a/sockets/networkMonitor.js
+++ b/sockets/networkMonitor.js
@@ -87,6 +87,7 @@ module.exports = function (app, connectionHandler, socket) {
 				cb('Peers');
 			},
 			(res) => {
+				logger.debug(`Returned ${res.list.connected.length} connected peers.`);
 				running.getPeers = false;
 				cb(null, res);
 			});


### PR DESCRIPTION
### What was the problem?
The number of connected peers displayed random values. The problem was caused on the backend side.

### How did I fix it?
I've found a bug in asynchronous function calls. The backend requests peers list and then combines it with FreeGeoIP results. The former solution didn't wait for the results and sent incomplete data after the last response from Lisk Core. At the time only small part of data was written to the peers list. The solution was to make sure that all peers are checked against the FreeGeoIP service before a response is sent.

### How to test it?
Open Network Monitor and check connected peers.

### Review checklist
- The PR solves #445 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
