### PR TITLE
Fix blocks page pagination - Closes #466

### DIFF
--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -97,14 +97,14 @@ module.exports = function (app) {
 			let totalPages = parseInt(height / 20, 10);
 			if (totalPages < height / 20) { totalPages++; }
 
-			if (pagination.currentPage < totalPages) {
+			if (pagination.currentPage > 1) {
 				pagination.before = true;
-				pagination.previousPage = pagination.currentPage + 1;
+				pagination.previousPage = pagination.currentPage - 1;
 			}
 
-			if (pagination.currentPage > 0) {
+			if (pagination.currentPage < totalPages) {
 				pagination.more = true;
-				pagination.nextPage = pagination.currentPage - 1;
+				pagination.nextPage = pagination.currentPage + 1;
 			}
 
 			return pagination;

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -45,10 +45,16 @@ describe('Blocks API', () => {
 
 	const checkPagination = (id) => {
 		node.expect(id).to.have.property('currentPage');
-		node.expect(id).to.have.property('more');
-		node.expect(id).to.have.property('previousPage');
-		node.expect(id).to.have.property('before');
-		node.expect(id).to.have.property('nextPage');
+
+		if (id.before) {
+			node.expect(id).to.have.property('previousPage');
+			node.expect(id.currentPage).to.gt(id.previousPage);
+		}
+
+		if (id.more) {
+			node.expect(id).to.have.property('nextPage');
+			node.expect(id.nextPage).to.gt(id.currentPage);
+		}
 	};
 
 	const checkLastBlock = (id) => {


### PR DESCRIPTION
### What was the problem?
The pagination buttons on blocks page was inverted

### How did I fix it?
I've fixed the pagination logic and added extra tests

### How to test it?
Go to /blocks page and test the pagination

### Review checklist
- The PR solves #466
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
