### PR TITLE
Fix a minor css regression

### DIFF
--- a/src/components/network-monitor/network-monitor.html
+++ b/src/components/network-monitor/network-monitor.html
@@ -233,7 +233,7 @@
 		</div>
 	</div>
 	<div class="row">
-		<div class="col-xs-12 big-info">
+		<div class="col-xs-12 big-info peers">
 			<h2>Connected peers <br /></h2>
 			<peers peers="vm.peers.connected"></peers>
 		</div>


### PR DESCRIPTION
### What was the problem?
Peers status and OS icons where not visible.

### How did I fix it?
A class name was dropped by #469

### How to test it?
OS icon and status should be visible in peers list in network monitor page.

### Review checklist
- The PR solves #494 
- All new code follows best practices