### PR TITLE
Add mapper for statistics/getPeers - Closes #497

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -344,6 +344,20 @@ module.exports = function (app) {
 		/* eslint-enable consistent-return */
 	}
 
+	const peersMapper = function (o) {
+		return {
+			ip: o.ip,
+			port: o.httpPort,
+			state: o.state,
+			os: o.os,
+			version: o.version,
+			broadhash: o.broadhash,
+			height: o.height,
+			osBrand: o.osBrand,
+			humanState: o.humanState,
+		};
+	};
+
 	this.getPeers = function (query, error, success) {
 		let offset = 0;
 		const limit = 100;
@@ -381,7 +395,14 @@ module.exports = function (app) {
 					logger.error(`Error retrieving Peers: ${err}`);
 					return error({ success: false, error: err });
 				}
-				return success({ success: true, list: peers.list });
+
+				return success({
+					success: true,
+					list: {
+						connected: (peers.list.connected || []).map(peersMapper),
+						disconnected: (peers.list.disconnected || []).map(peersMapper),
+					},
+				});
 			});
 	};
 };


### PR DESCRIPTION
### What was the problem?
The `/api/statistics/getPeers` response format was not compatible with the Explorer frontend.

### How did I fix it?
I wrote the mapper that ensures correct JSON output format.
 
### How to test it?
Run tests on test blockchain with multiple nodes.

### Review checklist
- The PR solves #497 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
