### PR TITLE
Peers mapper update - Solves #497

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -347,7 +347,7 @@ module.exports = function (app) {
 	const peersMapper = function (o) {
 		return {
 			ip: o.ip,
-			port: o.httpPort,
+			port: o.wsPort || 'n/a',
 			state: o.state,
 			os: o.os,
 			version: o.version,


### PR DESCRIPTION
Small update to the peers list Jenkins problem.
Since v1.0.0 some hosts do not provide httpPort param.
Using wsPoprt property makes sense because all nodes use WebSockets for this purpose since 1.0.0. 