### PR TITLE
Fix block height on top bar - Closes #472

### DIFF
--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -87,6 +87,13 @@ module.exports = function (app) {
 		};
 	}
 
+	function nodeStatusMapper(o) {
+		return {
+			broadhash: o.broadhash,
+			height: o.networkHeight,
+		};
+	}
+
 	function Blocks() {
 		this.offset = function (n) {
 			n = parseInt(n, 10);
@@ -296,7 +303,7 @@ module.exports = function (app) {
 				if (err || response.statusCode !== 200) {
 					return error({ success: false, error: (err || 'Response was unsuccessful') });
 				} else if (body && body.data) {
-					return cb(null, body.data);
+					return cb(null, nodeStatusMapper(body.data));
 				}
 				return error({ success: false, error: body.error });
 			});


### PR DESCRIPTION
### What was the problem?
The block height on top bar was showing the node height and not the network height

### How did I fix it?
I've added a mapping function to map the new api response

### How to test it?
Check if the block height on top bar is the highest block.

### Review checklist
- The PR solves #472
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
