### PR TITLE
Order peers list based on version number - Closes #449

### DIFF
--- a/src/components/network-monitor/network-monitor.service.js
+++ b/src/components/network-monitor/network-monitor.service.js
@@ -17,6 +17,38 @@ import leaflet from 'leaflet';
 import 'leaflet.markercluster';
 import AppNetworkMonitor from './network-monitor.module';
 
+/**
+ * Sorts given peers based on version strings
+ *
+ * @param {Object} p1 - First peer to compare
+ * @param {Object} p2 - Second peer to compare against
+ *
+ * @returns {Number} 1, -1, 0 if respectively greater, smaller or equal versions
+ */
+const sort = (p1, p2) => {
+	const v1 = p1.version;
+	const v2 = p2.version;
+	if (v1 === v2) return 0;
+
+	const v1Components = v1.toString().split('.').map(n => parseInt(n, 10));
+	const v2Components = v2.toString().split('.').map(n => parseInt(n, 10));
+	const char1 = v1.match(/[a-zA-Z]$/);
+	const char2 = v2.match(/[a-zA-Z]$/);
+	if (char1) v1Components.push(char1[0]);
+	if (char2) v2Components.push(char2[0]);
+
+	for (let i = 0; i < v1Components.length && i < v2Components.length; i++) {
+		if (v1Components[i] > v2Components[i]) return 1;
+		else if (v1Components[i] < v2Components[i]) return -1;
+	}
+
+	const diff = v1Components.length - v2Components.length;
+
+	if (diff > 0) return 1;
+	else if (diff < 0) return -1;
+	return 0;
+};
+
 const NetworkMap = function () {
 	this.markers = {};
 	this.options = { center: leaflet.latLng(40, 0), zoom: 1, minZoom: 1, maxZoom: 10 };
@@ -139,40 +171,9 @@ const NetworkMonitor = function (vm) {
 	const uniq = arrArg => arrArg.filter((elem, pos, arr) => arr.indexOf(elem) === pos);
 
 	function Versions(peers) {
-		/**
-		 * Sorts given version strings
-		 *
-		 * @param {String} v1
-		 * @param {String} v2
-		 *
-		 * @returns {Number} 1, -1, 0 if respectively greater, smaller or equal
-		 */
-		const sort = (v1, v2) => {
-			if (v1 === v2) return 0;
-
-			const v1Components = v1.toString().split('.').map(n => parseInt(n, 10));
-			const v2Components = v2.toString().split('.').map(n => parseInt(n, 10));
-			const char1 = v1.match(/[a-zA-Z]$/);
-			const char2 = v2.match(/[a-zA-Z]$/);
-			if (char1) v1Components.push(char1[0]);
-			if (char2) v2Components.push(char2[0]);
-
-			for (let i = 0; i < v1Components.length && i < v2Components.length; i++) {
-				if (v1Components[i] > v2Components[i]) return 1;
-				else if (v1Components[i] < v2Components[i]) return -1;
-			}
-
-			const diff = v1Components.length - v2Components.length;
-
-			if (diff > 0) return 1;
-			else if (diff < 0) return -1;
-			return 0;
-		};
-
 		const inspect = () => {
 			if (peers instanceof Array) {
-				return uniq(peers.map(p => p.version)
-					.sort(sort)).reverse().slice(0, 3);
+				return uniq(peers.map(p => p.version)).slice(0, 3);
 			}
 			return [];
 		};
@@ -268,8 +269,7 @@ const NetworkMonitor = function (vm) {
 
 		return {
 			connected: peers.connected.length,
-			disconnected: peers.disconnected.length,
-			total: peers.connected.length + peers.disconnected.length,
+			total: peers.connected.length,
 			platforms: platforms.detected(),
 			versions: versions.detected(),
 			heights: heights.detected(),
@@ -278,9 +278,12 @@ const NetworkMonitor = function (vm) {
 	};
 
 	this.updatePeers = function (peers) {
-		vm.peers = peers.list;
-		vm.counter = this.counter(peers.list);
-		this.map.addConnected(peers.list);
+		vm.peers = {
+			connected: peers.list.connected.sort(sort).reverse(),
+		};
+
+		vm.counter = this.counter(vm.peers);
+		this.map.addConnected(vm.peers);
 	};
 
 	this.updateLastBlock = (lastBlock) => {

--- a/src/components/network-monitor/network-monitor.service.js
+++ b/src/components/network-monitor/network-monitor.service.js
@@ -25,9 +25,9 @@ import AppNetworkMonitor from './network-monitor.module';
  *
  * @returns {Number} 1, -1, 0 if respectively greater, smaller or equal versions
  */
-const sort = (p1, p2) => {
-	const v1 = p1.version;
-	const v2 = p2.version;
+const sortByVersion = (p1, p2) => {
+	const v1 = typeof p1 === 'string' ? p1 : p1.version;
+	const v2 = typeof p2 === 'string' ? p2 : p2.version;
 	if (v1 === v2) return 0;
 
 	const v1Components = v1.toString().split('.').map(n => parseInt(n, 10));
@@ -173,7 +173,7 @@ const NetworkMonitor = function (vm) {
 	function Versions(peers) {
 		const inspect = () => {
 			if (peers instanceof Array) {
-				return uniq(peers.map(p => p.version)).slice(0, 3);
+				return uniq(peers.map(p => p.version)).sort(sortByVersion).reverse().slice(0, 3);
 			}
 			return [];
 		};
@@ -278,8 +278,9 @@ const NetworkMonitor = function (vm) {
 	};
 
 	this.updatePeers = function (peers) {
+		// default sort in sort by version
 		vm.peers = {
-			connected: peers.list.connected.sort(sort).reverse(),
+			connected: peers.list.connected.sort(sortByVersion).reverse(),
 		};
 
 		vm.counter = this.counter(vm.peers);

--- a/src/components/network-monitor/network-monitor.service.js
+++ b/src/components/network-monitor/network-monitor.service.js
@@ -280,7 +280,7 @@ const NetworkMonitor = function (vm) {
 	this.updatePeers = function (peers) {
 		// default sort in sort by version
 		vm.peers = {
-			connected: peers.list.connected.sort(sortByVersion).reverse(),
+			connected: peers.list.connected,
 		};
 
 		vm.counter = this.counter(vm.peers);
@@ -301,9 +301,13 @@ AppNetworkMonitor.factory('networkMonitor',
 	($socket, $rootScope) => (vm) => {
 		const networkMonitor = new NetworkMonitor(vm);
 		const ns = $socket('/networkMonitor');
+		const rate = 3;
+		let period = 0;
 
 		ns.on('data', (res) => {
-			if (res.peers) { networkMonitor.updatePeers(res.peers); }
+			if (res.peers) {
+				networkMonitor.updatePeers(res.peers);
+			}
 			if (res.lastBlock) { networkMonitor.updateLastBlock(res.lastBlock); }
 			if (res.blocks) { networkMonitor.updateBlocks(res.blocks); }
 		});
@@ -322,7 +326,10 @@ AppNetworkMonitor.factory('networkMonitor',
 
 		ns.on('data3', (res) => {
 			if (res.peers) {
-				networkMonitor.updatePeers(res.peers);
+				period = (period >= rate) ? 0 : (period + 1);
+				if (period === rate - 1) {
+					networkMonitor.updatePeers(res.peers);
+				}
 			}
 		});
 

--- a/src/services/order-by.js
+++ b/src/services/order-by.js
@@ -47,11 +47,16 @@ const sortByVersion = (p1, p2) => {
 	return 0;
 };
 
-const numericSort = (p1, p2, key) => p1[key] - p2[key];
+const osSort = (p1, p2) => {
+	if (p1 === p2) return 0;
+	return (p1 > p2) ? 1 : -1;
+};
 
-const stringSort = (p1, p2, key) => {
-	if (p1[key] === p2[key]) return 0;
-	return (p1[key] > p2[key]) ? 1 : -1;
+const numericSort = (p1, p2) => p1 - p2;
+
+const stringSort = (p1, p2) => {
+	if (p1 === p2) return 0;
+	return (p1 > p2) ? 1 : -1;
 };
 
 const OrderBy = function (predicate) {
@@ -65,12 +70,15 @@ const OrderBy = function (predicate) {
 
 	this.order = (el1, el2) => {
 		if (this.predicate === 'version') {
-			return sortByVersion(el1, el2);
+			return sortByVersion(el1.value, el2.value);
 		}
 		if (this.predicate === 'port' || this.predicate === 'height') {
-			return numericSort(el1, el2, this.predicate);
+			return numericSort(el1.value, el2.value);
 		}
-		return stringSort(el1, el2, this.predicate);
+		if (this.predicate === 'os') {
+			return osSort(el1.value, el2.value);
+		}
+		return stringSort(el1.value, el2.value);
 	};
 };
 

--- a/src/services/order-by.js
+++ b/src/services/order-by.js
@@ -15,13 +15,62 @@
  */
 import AppServices from './services.module';
 
+/**
+ * Sorts given peers based on version strings
+ *
+ * @param {Object} p1 - First peer to compare
+ * @param {Object} p2 - Second peer to compare against
+ *
+ * @returns {Number} 1, -1, 0 if respectively greater, smaller or equal versions
+ */
+const sortByVersion = (p1, p2) => {
+	const v1 = typeof p1 === 'string' ? p1 : p1.version;
+	const v2 = typeof p2 === 'string' ? p2 : p2.version;
+	if (v1 === v2) return 0;
+
+	const v1Components = v1.toString().split('.').map(n => parseInt(n, 10));
+	const v2Components = v2.toString().split('.').map(n => parseInt(n, 10));
+	const char1 = v1.match(/[a-zA-Z]$/);
+	const char2 = v2.match(/[a-zA-Z]$/);
+	if (char1) v1Components.push(char1[0]);
+	if (char2) v2Components.push(char2[0]);
+
+	for (let i = 0; i < v1Components.length && i < v2Components.length; i++) {
+		if (v1Components[i] > v2Components[i]) return 1;
+		else if (v1Components[i] < v2Components[i]) return -1;
+	}
+
+	const diff = v1Components.length - v2Components.length;
+
+	if (diff > 0) return 1;
+	else if (diff < 0) return -1;
+	return 0;
+};
+
+const numericSort = (p1, p2, key) => p1[key] - p2[key];
+
+const stringSort = (p1, p2, key) => {
+	if (p1[key] === p2[key]) return 0;
+	return (p1[key] > p2[key]) ? 1 : -1;
+};
+
 const OrderBy = function (predicate) {
 	this.reverse = false;
 	this.predicate = predicate;
 
-	this.order = function (currentPredicate) {
+	this.setPredicate = (currentPredicate) => {
 		this.reverse = (this.predicate === currentPredicate) ? !this.reverse : false;
 		this.predicate = currentPredicate;
+	};
+
+	this.order = (el1, el2) => {
+		if (this.predicate === 'version') {
+			return sortByVersion(el1, el2);
+		}
+		if (this.predicate === 'port' || this.predicate === 'height') {
+			return numericSort(el1, el2, this.predicate);
+		}
+		return stringSort(el1, el2, this.predicate);
 	};
 };
 

--- a/src/shared/peers/peers.html
+++ b/src/shared/peers/peers.html
@@ -36,7 +36,7 @@
 		</tbody>
 		<tbody>
 			<tr data-ng-repeat='p in peers | orderBy:table.predicate:table.reverse:table.order track by $index + p.ip'>
-				<td><span class="text-muted">{{p.ip}}</span></td>
+				<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><span class="text-muted">{{p.ip}}</span></td>
 				<td><span class="text-muted">{{p.port}}</span></td>
 				<td class="hidden-xs"><span class="text-muted ellipsis hostname" title="{{p.location.hostname}}">{{p.location.hostname || 'N/A'}}</span></td>
 				<td class="hidden-xs"><span class="flag flag-{{p.location.country_code | lowercase}}" title="{{p.location.country_name}}" /></td>

--- a/src/shared/peers/peers.html
+++ b/src/shared/peers/peers.html
@@ -19,14 +19,14 @@
 	<table class="table table-hover table-striped">
 		<thead>
 			<tr>
-				<th class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><a href="" data-ng-click="table.order('ip')" class="sort-order">IP Address <span data-ng-show="table.predicate === 'ip'" data-ng-class="{reverse:table.reverse}"></span></a></th>
-				<th><a href="" data-ng-click="table.order('port')" class="sort-order">Port <span data-ng-show="table.predicate === 'port'" data-ng-class="{reverse:table.reverse}"></span></a></th>
-				<th class="hidden-xs host-row"><a href="" data-ng-click="table.order('location.hostname')" class="sort-order">Hostname <span data-ng-show="table.predicate === 'location.hostname'" data-ng-class="{reverse:table.reverse}"></span></a></th>
-				<th class="hidden-xs"><a href="" data-ng-click="table.order('location.country_name')" class="sort-order">Country <span data-ng-show="table.predicate === 'location.country_name'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><a href="" data-ng-click="table.setPredicate('ip')" class="sort-order">IP Address <span data-ng-show="table.predicate === 'ip'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th><a href="" data-ng-click="table.setPredicate('port')" class="sort-order">Port <span data-ng-show="table.predicate === 'port'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th class="hidden-xs host-row"><a href="" data-ng-click="table.setPredicate('location.hostname')" class="sort-order">Hostname <span data-ng-show="table.predicate === 'location.hostname'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th class="hidden-xs"><a href="" data-ng-click="table.setPredicate('location.country_name')" class="sort-order">Country <span data-ng-show="table.predicate === 'location.country_name'" data-ng-class="{reverse:table.reverse}"></span></a></th>
 				<th>Status</th>
-				<th><a href="" data-ng-click="table.order('version')" class="sort-order">Version <span data-ng-show="table.predicate === 'version'" data-ng-class="{reverse:table.reverse}"></span></a></th>
-				<th><a href="" data-ng-click="table.order('os')" class="sort-order">Platform <span data-ng-show="table.predicate === 'os'" data-ng-class="{reverse:table.reverse}"></span></a></th>
-				<th class="hidden-xs hidden-sm right-padding-m right-padding-l double"><a href="" data-ng-click="table.order('height')" class="sort-order">Height <span data-ng-show="table.predicate === 'height'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th><a href="" data-ng-click="table.setPredicate('version')" class="sort-order">Version <span data-ng-show="table.predicate === 'version'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th><a href="" data-ng-click="table.setPredicate('os')" class="sort-order">Platform <span data-ng-show="table.predicate === 'os'" data-ng-class="{reverse:table.reverse}"></span></a></th>
+				<th class="hidden-xs hidden-sm right-padding-m right-padding-l double"><a href="" data-ng-click="table.setPredicate('height')" class="sort-order">Height <span data-ng-show="table.predicate === 'height'" data-ng-class="{reverse:table.reverse}"></span></a></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -35,8 +35,8 @@
 			</tr>
 		</tbody>
 		<tbody>
-			<tr data-ng-repeat='p in peers | orderBy:table.predicate:table.reverse track by $index + p.ip'>
-				<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><span class="text-muted">{{p.ip}}</span></td>
+			<tr data-ng-repeat='p in peers | orderBy:table.predicate:table.reverse:table.order track by $index + p.ip'>
+				<td><span class="text-muted">{{p.ip}}</span></td>
 				<td><span class="text-muted">{{p.port}}</span></td>
 				<td class="hidden-xs"><span class="text-muted ellipsis hostname" title="{{p.location.hostname}}">{{p.location.hostname || 'N/A'}}</span></td>
 				<td class="hidden-xs"><span class="flag flag-{{p.location.country_code | lowercase}}" title="{{p.location.country_name}}" /></td>


### PR DESCRIPTION
### What was the problem?
Explained in #449 

### How did I fix it?
We had a sort function applies to find the most recent versions, I used the same sort function to order the entire peers list and bound it to view.

### Review checklist
- The PR solves #449 
- All new code follows best practices
