### PR TITLE
Geolocation data included in the Network Monitor socket response - Closes #517

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -356,6 +356,7 @@ module.exports = function (app) {
 			height: o.height,
 			osBrand: o.osBrand,
 			humanState: o.humanState,
+			location: o.location,
 		};
 	};
 


### PR DESCRIPTION
### What was the problem?
Geolocation data was not visible in the Network Monitor peers table.

### How did I fix it?
I've added `location` field in the mapping definition. 

### How to test it?
Open the Network Monitor

### Review checklist
- The PR solves #517
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
