### PR TITLE
Locked npm version in the Dockerfile - Closes #491

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY . /home/lisk/lisk-explorer/
 RUN useradd lisk && \
     chown lisk:lisk -R /home/lisk
 USER lisk
+RUN npm install -g npm@5.7.1 
 RUN cd /home/lisk/lisk-explorer && \
     npm install
 RUN cd /home/lisk/lisk-explorer && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install --no-install-recommends \
         build-essential \
 	redis-server && \
+    npm install -g npm@5.7.1 \
     npm install -g grunt && \
     npm install -g bower
 
@@ -11,7 +12,6 @@ COPY . /home/lisk/lisk-explorer/
 RUN useradd lisk && \
     chown lisk:lisk -R /home/lisk
 USER lisk
-RUN npm install -g npm@5.7.1 
 RUN cd /home/lisk/lisk-explorer && \
     npm install
 RUN cd /home/lisk/lisk-explorer && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 FROM node:6 AS builder
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install --no-install-recommends \
-        build-essential \
-	    redis-server && \
-    npm install -g npm@5.7.1 && \
-    npm install -g grunt && \
-    npm install -g bower
+	DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install --no-install-recommends \
+		build-essential \
+		redis-server && \
+	npm install -g npm@5.7.1 && \
+	npm install -g grunt && \
+	npm install -g bower
 
 COPY . /home/lisk/lisk-explorer/
 RUN useradd lisk && \
-    chown lisk:lisk -R /home/lisk
+	chown lisk:lisk -R /home/lisk
 USER lisk
 RUN cd /home/lisk/lisk-explorer && \
-    npm install
+	npm install
 RUN cd /home/lisk/lisk-explorer && \
-    npm run build
+	npm run build
 
 
 FROM node:6-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:6 AS builder
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install --no-install-recommends \
         build-essential \
-	redis-server && \
-    npm install -g npm@5.7.1 \
+	    redis-server && \
+    npm install -g npm@5.7.1 && \
     npm install -g grunt && \
     npm install -g bower
 


### PR DESCRIPTION
Current update forces Docker build container to use npm version 5.7.1
### Review checklist
- The PR solves #491
- All new code follows best practices
