### PR TITLE
Fix all transactions tab - Closes #499

### DIFF
--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -402,11 +402,9 @@ module.exports = function (app) {
 		}
 
 		const directionQueries = [];
-		let baseQuery;
+		let baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${param(params.limit, 100)}`;
 		let recipientQuery;
 		let senderQuery;
-
-		baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${params.limit}`;
 
 		if (params.timestampQuery) {
 			baseQuery = `${baseQuery}&${params.timestampQuery}=${param(params.timestamp, 0)}`;

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -402,7 +402,15 @@ module.exports = function (app) {
 		}
 
 		const directionQueries = [];
-		const baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${param(params.limit, 100)}`;
+		let baseQuery;
+
+		if (params.timestamp === '0') {
+			baseQuery = `sort=timestamp:desc&fromTimestamp=${param(params.timestamp, 0)}&limit=${params.limit}`;
+		} else if (params.timestamp) {
+			baseQuery = `sort=timestamp:desc&toTimestamp=${param(params.timestamp, 1)}&limit=${params.limit}`;
+		} else {
+			baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${params.limit}`;
+		}
 
 		if (params.direction === 'sent') {
 			directionQueries.push(`${baseQuery}&senderId=${params.address}&type=0`);
@@ -413,7 +421,8 @@ module.exports = function (app) {
 				directionQueries.push(`${baseQuery}&senderId=${params.address}&type=${i}`);
 			}
 		} else if (params.address) {
-			directionQueries.push(`${baseQuery}&recipientId=${params.address}`); // should be or &senderId=${params.address}
+			directionQueries.push(`${baseQuery}&recipientId=${params.address}&offset=${param(params.recipientOffset, 0)}`);
+			directionQueries.push(`${baseQuery}&senderId=${params.address}&offset=${param(params.senderOffset, 0)}`);
 		} else {
 			// advanced search
 			let advanced = '';
@@ -495,6 +504,10 @@ module.exports = function (app) {
 					});
 				});
 				/* eslint-enable consistent-return */
+			},
+			(result, cb) => {
+				result = result.sort((a, b) => b.timestamp - a.timestamp).slice(0, query.limit);
+				cb(null, result);
 			},
 			processTransactions,
 		], (err, result) => {

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -470,54 +470,40 @@ module.exports = function (app) {
 	};
 
 	this.getTransactionsByAddress = function (query, error, success) {
-		const data = normalizeTransactionParams(query, error);
-		if (typeof data === 'string') {
-			return error({ success: false, error: data });
+		const queryList = normalizeTransactionParams(query, error);
+		if (typeof queryList === 'string') {
+			return error({ success: false, error: queryList });
 		}
 
-		const indexOfById = (list, item) => {
-			let index = -1;
-			list.forEach((mem, i) => {
-				if (mem.id === item.id) {
-					index = i;
+		const queryCallsList = queryList.map(directionQuery => (callback) => {
+			request.get({
+				url: `${app.get('lisk address')}/transactions?${directionQuery}`,
+				json: true,
+			}, (err, response, body) => {
+				if (err || response.statusCode !== 200) {
+					callback(err || 'Response was unsuccessful');
+				} else if (body && Array.isArray(body.data)) {
+					callback(null, body.data);
+				} else {
+					callback(body.error || 'Response was unsuccessful');
 				}
 			});
-
-			return index;
-		};
+		});
 
 		return async.waterfall([
 			function (cb) {
-				const transactionsList = [];
-				let errorMessage;
-				/* eslint-disable consistent-return */
-				data.forEach((directionQuery, index) => {
-					request.get({
-						url: `${app.get('lisk address')}/transactions?${directionQuery}`,
-						json: true,
-					}, (err, response, body) => {
-						if (err || response.statusCode !== 200) {
-							errorMessage = (err || 'Response was unsuccessful');
-						} else if (body && Array.isArray(body.data)) {
-							body.data.forEach((transaction) => {
-								if (indexOfById(transactionsList, transaction) < 0) {
-									transactionsList.push(transaction);
-								}
-							});
-						} else {
-							errorMessage = body.error;
+				async.parallel(
+					queryCallsList,
+					(err, results) => {
+						if (err) {
+							return error({ success: false, error: err });
 						}
-						if (index === data.length - 1) {
-							return (transactionsList.length > 0 || !errorMessage) ?
-								cb(null, transactionsList) :
-								error({ success: false, error: errorMessage });
-						}
+						return cb(null, _.uniq(_.flatten(results), 'id'));
 					});
-				});
-				/* eslint-enable consistent-return */
 			},
 			(result, cb) => {
 				result = result.sort((a, b) => b.timestamp - a.timestamp).slice(0, query.limit);
+
 				cb(null, result);
 			},
 			processTransactions,

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -502,7 +502,9 @@ module.exports = function (app) {
 					});
 			},
 			(result, cb) => {
-				result = result.sort((a, b) => b.timestamp - a.timestamp).slice(0, query.limit);
+				if (query.timestampQuery) {
+					result = result.sort((a, b) => a.timestamp - b.timestamp).reverse().slice(0, query.limit);
+				}
 
 				cb(null, result);
 			},

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -403,13 +403,15 @@ module.exports = function (app) {
 
 		const directionQueries = [];
 		let baseQuery;
+		let recipientQuery;
+		let senderQuery;
+
+		baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${params.limit}`;
 
 		if (params.timestamp === '0') {
-			baseQuery = `sort=timestamp:desc&fromTimestamp=${param(params.timestamp, 0)}&limit=${params.limit}`;
+			baseQuery = `${baseQuery}&fromTimestamp=${param(params.timestamp, 0)}`;
 		} else if (params.timestamp) {
-			baseQuery = `sort=timestamp:desc&toTimestamp=${param(params.timestamp, 1)}&limit=${params.limit}`;
-		} else {
-			baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${params.limit}`;
+			baseQuery = `${baseQuery}&toTimestamp=${param(params.timestamp, 1)}`;
 		}
 
 		if (params.direction === 'sent') {
@@ -421,8 +423,19 @@ module.exports = function (app) {
 				directionQueries.push(`${baseQuery}&senderId=${params.address}&type=${i}`);
 			}
 		} else if (params.address) {
-			directionQueries.push(`${baseQuery}&recipientId=${params.address}&offset=${param(params.recipientOffset, 0)}`);
-			directionQueries.push(`${baseQuery}&senderId=${params.address}&offset=${param(params.senderOffset, 0)}`);
+			recipientQuery = `${baseQuery}&recipientId=${params.address}`;
+			senderQuery = `${baseQuery}&senderId=${params.address}`;
+
+			if (params.recipientOffset) {
+				recipientQuery.replace(`offset=${param(params.offset, 0)}`, `offset=${param(params.recipientOffset, 0)}`);
+			}
+
+			if (params.senderOffset) {
+				senderQuery.replace(`offset=${param(params.offset, 0)}`, `offset=${param(params.senderOffset, 0)}`);
+			}
+
+			directionQueries.push(recipientQuery);
+			directionQueries.push(senderQuery);
 		} else {
 			// advanced search
 			let advanced = '';

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -408,10 +408,8 @@ module.exports = function (app) {
 
 		baseQuery = `sort=timestamp:desc&offset=${param(params.offset, 0)}&limit=${params.limit}`;
 
-		if (params.timestamp === '0') {
-			baseQuery = `${baseQuery}&fromTimestamp=${param(params.timestamp, 0)}`;
-		} else if (params.timestamp) {
-			baseQuery = `${baseQuery}&toTimestamp=${param(params.timestamp, 1)}`;
+		if (params.timestampQuery) {
+			baseQuery = `${baseQuery}&${params.timestampQuery}=${param(params.timestamp, 0)}`;
 		}
 
 		if (params.direction === 'sent') {

--- a/src/services/address-txs.js
+++ b/src/services/address-txs.js
@@ -15,15 +15,24 @@
  */
 import AppServices from './services.module';
 import LessMore from './less-more';
+import LessMoreByTimestamp from './less-more-by-timestamp';
 
 AppServices.factory('addressTxs',
 	($http, $q) => (data) => {
+		let LessMoreModule;
 		const params = Object.assign({}, data, {
 			url: '/api/getTransactionsByAddress',
 			parent: 'address',
 			key: 'transactions',
 		});
-		const lessMore = new LessMore($http, $q, params);
+
+		if (params.direction) {
+			LessMoreModule = LessMore;
+		} else {
+			LessMoreModule = LessMoreByTimestamp;
+		}
+
+		const lessMore = new LessMoreModule($http, $q, params);
 
 		lessMore.loadMore = function () {
 			this.getData(0, 1, (response) => {
@@ -35,7 +44,7 @@ AppServices.factory('addressTxs',
 				if (changed) {
 					this.reloadMore();
 				} else {
-					LessMore.prototype.loadMore.call(this);
+					LessMoreModule.prototype.loadMore.call(this);
 				}
 			});
 		};

--- a/src/services/less-more-by-timestamp.js
+++ b/src/services/less-more-by-timestamp.js
@@ -56,6 +56,11 @@ LessMoreByTimestamp.prototype.getData = function (timestamp, limit, cb) {
 	const params = Object.assign({}, { timestamp, limit }, this.params);
 	this.disable();
 	this.loading = true;
+
+	if (timestamp === 0) {
+		params.timestampQuery = 'fromTimestamp';
+	}
+
 	this.$http.get(this.url, {
 		params,
 	}).then((resp) => {
@@ -120,6 +125,7 @@ LessMoreByTimestamp.prototype.loadMore = function () {
 	const lastItems = this.results.filter(item => item.timestamp === this.timestamp);
 	params.recipientOffset = lastItems.filter(item => item.recipientId === params.address).length;
 	params.senderOffset = lastItems.filter(item => item.senderId === params.address).length;
+	params.timestampQuery = 'toTimestamp';
 	this.getData(this.timestamp, (this.limit + 1),
 		(data) => {
 			this.acceptData(data);
@@ -127,7 +133,11 @@ LessMoreByTimestamp.prototype.loadMore = function () {
 };
 
 LessMoreByTimestamp.prototype.reloadMore = function () {
-	// TODO
+	this.params.timestampQuery = 'fromTimestamp';
+	this.getData(this.timestamp, (this.limit + 1),
+		(data) => {
+			this.acceptData(data);
+		});
 	return true;
 };
 

--- a/src/services/less-more-by-timestamp.js
+++ b/src/services/less-more-by-timestamp.js
@@ -1,0 +1,162 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import angular from 'angular';
+import AppServices from './services.module';
+
+const LessMoreByTimestamp = function ($http, $q, params) {
+	this.$http = $http;
+	this.$q = $q;
+
+	this.url = params.url || '';
+	this.parent = params.parent || 'parent';
+	this.key = params.key || '';
+	this.timestamp = params.timestamp || 0;
+	this.maximum = params.maximum || 2000;
+	this.limit = params.limit || 50;
+
+	['url', 'parent', 'key', 'timestamp', 'maximum', 'limit'].forEach((key) => {
+		delete params[key];
+	});
+
+	this.params = params;
+	this.results = [];
+	this.splice = 0;
+	this.loading = true;
+	this.moreData = false;
+	this.lessData = false;
+};
+
+LessMoreByTimestamp.prototype.getLastItem = function () {
+	return this.results[this.results.length - 1];
+};
+
+LessMoreByTimestamp.prototype.disable = function () {
+	this.moreData = false;
+	this.lessData = false;
+};
+
+LessMoreByTimestamp.prototype.disabled = function () {
+	return !this.moreData && !this.lessData;
+};
+
+LessMoreByTimestamp.prototype.getData = function (timestamp, limit, cb) {
+	const params = Object.assign({}, { timestamp, limit }, this.params);
+	this.disable();
+	this.loading = true;
+	this.$http.get(this.url, {
+		params,
+	}).then((resp) => {
+		if (resp.data.success && angular.isArray(resp.data[this.key])) {
+			cb(resp.data[this.key]);
+		} else {
+			throw new Error('LessMoreByTimestamp failed to get valid response data');
+		}
+	});
+};
+
+LessMoreByTimestamp.prototype.anyMore = function (length) {
+	return (this.limit <= 1 && (this.limit % length) === 1) ||
+		(length > 1 && this.limit >= 1 && (length % this.limit) === 1);
+};
+
+LessMoreByTimestamp.prototype.spliceData = function (data) {
+	if (this.anyMore(angular.isArray(data) ? data.length : 0)) {
+		this.moreData = true;
+		data.splice(-1, 1);
+	} else {
+		this.moreData = false;
+	}
+};
+
+LessMoreByTimestamp.prototype.acceptData = function (data) {
+	if (!angular.isArray(data)) { data = []; }
+
+	this.spliceData(data);
+
+	if (this.results.length > 0) {
+		data.forEach((transaction) => {
+			const pos = this.results.map(e => e.id).indexOf(transaction.id);
+			if (pos < 0) {
+				this.results.push(transaction);
+			}
+		});
+	} else {
+		this.results = data;
+	}
+
+	if ((this.results.length + this.limit) > this.maximum) {
+		this.moreData = false;
+	}
+
+	this.lessData = this.anyLess(this.results.length);
+	this.loading = false;
+	delete this.params.recipientOffset;
+	delete this.params.senderOffset;
+	this.updateTimestamp();
+};
+
+LessMoreByTimestamp.prototype.loadData = function () {
+	this.getData(0, (this.limit + 1),
+		(data) => {
+			this.acceptData(data);
+		});
+};
+
+LessMoreByTimestamp.prototype.loadMore = function () {
+	const { params } = this;
+	const lastItems = this.results.filter(item => item.timestamp === this.timestamp);
+	params.recipientOffset = lastItems.filter(item => item.recipientId === params.address).length;
+	params.senderOffset = lastItems.filter(item => item.senderId === params.address).length;
+	this.getData(this.timestamp, (this.limit + 1),
+		(data) => {
+			this.acceptData(data);
+		});
+};
+
+LessMoreByTimestamp.prototype.reloadMore = function () {
+	// TODO
+	return true;
+};
+
+LessMoreByTimestamp.prototype.updateTimestamp = function () {
+	this.timestamp = this.getLastItem().timestamp;
+	return this.timestamp;
+};
+
+LessMoreByTimestamp.prototype.anyLess = function (length) {
+	if (length > this.limit) {
+		const mod = length % this.limit;
+		this.splice = (mod === 0) ? this.limit : mod;
+		return true;
+	}
+	this.splice = 0;
+	return false;
+};
+
+LessMoreByTimestamp.prototype.loadLess = function () {
+	this.lessData = false;
+	this.moreData = true;
+	if (angular.isArray(this.results)) {
+		this.results.splice(-this.splice, this.splice);
+		this.lessData = this.anyLess(this.results.length);
+	}
+	this.updateTimestamp();
+};
+
+AppServices.factory('lessMoreByTimestamp',
+	($http, $q) => params => new LessMoreByTimestamp($http, $q, params));
+
+export default LessMoreByTimestamp;


### PR DESCRIPTION
### What was the problem?
All Transactions tab was showing only the received transactions

### How did I fix it?
As the new core api returns the intersection result when sending both recipientId and senderId, I'm making 2 calls (one for each case). But in order to keep the consistency when merging the 2 responses and to deal with more/less feature, I've implemented a new LessMore angular module called LessMoreByTimestamp to cater for this particular scenario.

### How to test it?
You should see Sent and Received transactions on All Transactions tab on Address page

### Review checklist
- The PR solves #499
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
