### PR TITLE
Check if delegate last block is present - Closes #529

### DIFF
--- a/sockets/delegateMonitor.js
+++ b/sockets/delegateMonitor.js
@@ -197,10 +197,15 @@ module.exports = function (app, connectionHandler, socket) {
 				// Set last block and his delegate (we will emit it later in emitData)
 				data.lastBlock.block = result.blocks[0];
 				const lastBlockDelegate = findActiveByBlock(data.lastBlock.block);
-				data.lastBlock.block.delegate = {
-					username: lastBlockDelegate.username,
-					address: lastBlockDelegate.address,
-				};
+
+				data.lastBlock.block.delegate = {};
+
+				if (lastBlockDelegate) {
+					data.lastBlock.block.delegate = {
+						username: lastBlockDelegate.username,
+						address: lastBlockDelegate.address,
+					};
+				}
 
 				async.eachSeries(result.blocks, (b, cb) => {
 					let existing = findActiveByBlock(b);


### PR DESCRIPTION
### What was the problem?
Application crashes when there is no previous block generated by an active delegate

### How did I fix it?
Added a check before assigning the variables

### How to test it?
Run the application with less than 100 blocks generated

### Review checklist
- The PR solves #529 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
