### PR TITLE
Fix delegate url on delegagte monitor page

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -276,7 +276,7 @@ module.exports = function (app) {
 					tx.delegate = null;
 					return cb();
 				} else if (body && Array.isArray(body.data)) {
-					tx.delegate = body.data[0];
+					tx.delegate = delegatesMapper(body.data[0]);
 					return cb(tx);
 				}
 				tx.delegate = null;


### PR DESCRIPTION
### What was the problem?
The url for delegates on Latest Votes list on Delegate Monitor was pointing to 'undefined'

### How did I fix it?
Applied the delegatesMapper function to core response

### How to test it?
Access /delegateMonitor
You should be able to click on a delegate on Latest Votes list and navigate to its page

### Review checklist
- The PR solves #528 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
