### PR TITLE
Invalid reverse dns fix - Closes #540

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -186,18 +186,23 @@ module.exports = function (app) {
 		};
 
 		const getHostName = (ip, cb) => {
-			dns.reverse(ip, (err, hostnames) => {
-				let hostname;
+			const unknownHostname = `${ip}.unknown`;
+			try {
+				dns.reverse(ip, (err, hostnames) => {
+					let hostname;
 
-				if (err) {
-					logger.debug('Locator:', 'Failed to get new hostname for:', ip);
-					hostname = `${ip}.unknown`;
-				} else {
-					hostname = hostnames[0];
-				}
+					if (err) {
+						logger.debug('Locator:', 'Failed to get new hostname for:', ip);
+						hostname = unknownHostname;
+					} else {
+						hostname = hostnames[0];
+					}
 
-				return cb(err, hostname);
-			});
+					return cb(err, hostname);
+				});
+			} catch (err) {
+				cb(err, unknownHostname);
+			}
 		};
 
 		const getLocation = (ip, cb) => {


### PR DESCRIPTION
### What was the problem?
The built-in dns module raised an unhandled exception in case of invalid IP address.

### How did I fix it?
The failing code is wrapped around a try-catch block. Due to non-critical importance of this issue, we handle all reverse DNS problems same way - by returning a hostname in the following format: `nnn.nnn.nnn.nnn.unknown'.

### How to test it?
There is no clear way to reproduce the bug. The problem should not exist anymore on the alpha- and betanet.

### Review checklist
- The PR solves #540
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
