### PR TITLE
Fix latest votes list not showing username - Closes #544

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -274,12 +274,9 @@ module.exports = function (app) {
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
 					tx.delegate = null;
-					return cb();
 				} else if (body && Array.isArray(body.data)) {
 					tx.delegate = delegatesMapper(body.data[0]);
-					return cb(tx);
 				}
-				tx.delegate = null;
 				return cb();
 			});
 		};


### PR DESCRIPTION
### What was the problem?
Latest votes list wasn't showing delegate username

### How did I fix it?
I've removed premature callback call

### How to test it?
Access `/delegateMonitor`. You should always see the delegate username when the voter is a delegate

### Review checklist
- The PR solves #544 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
