### PR TITLE
Network Monitor: Incorrect best block amount - Closes #547

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -59,22 +59,27 @@ module.exports = function (app) {
 				if (this.volume.blocks >= this.maxCount) { break; }
 
 				const newBlock = blocks[i];
-				const newAmount = (Number(newBlock.totalAmount) + Number(newBlock.totalFee));
+				newBlock.totalAmount = Number(newBlock.totalAmount);
+				newBlock.totalFee = Number(newBlock.totalFee);
+				newBlock.reward = Number(newBlock.reward);
+				newBlock.totalForged = Number(newBlock.totalForged);
+
+				const newAmount = newBlock.totalAmount + newBlock.totalFee;
 
 				this.volume.blocks += 1;
-				this.volume.txs += Number(newBlock.numberOfTransactions);
-				this.volume.amount += Number(newAmount);
+				this.volume.txs += newBlock.numberOfTransactions;
+				this.volume.amount += newAmount;
 
 				if (this.best.block === null) {
 					this.best.block = newBlock;
 				}
 
-				if (Number(newAmount) > 0) {
+				if (newAmount > 0) {
 					this.volume.withTxs += 1;
 
-					if (Number(newAmount) > Number(this.best.amount)) {
+					if (newAmount > this.best.amount) {
 						this.best.block = newBlock;
-						this.best.amount = Number(newAmount);
+						this.best.amount = newAmount;
 					}
 				}
 			}


### PR DESCRIPTION
### What was the problem?
Some block attributes was string when it should be number

### How did I fix it?
Casting those attributes to number

### How to test it?
Access `/networkMonitor` and check Best Block section.
The amount should match the Total Amount plus the Total Fee for that block

### Review checklist
- The PR solves #547 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
