### PR TITLE
Latest Blocks list not showing username - Closes #555

### DIFF
--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -131,7 +131,7 @@ module.exports = function (app) {
 				totalForged: b.totalForged,
 				transactionsCount: b.numberOfTransactions,
 				height: b.height,
-				delegate: b.generatorAddress,
+				delegate: b.delegate,
 			}));
 		};
 


### PR DESCRIPTION
### What was the problem?
The latest blocks list on the home page wasn't showing the delegate username

### How did I fix it?
I've fixed the block mapping function which was assigning the wrong value to delegate attribute

### How to test it?
Access the home page and check the "Generated by" column on Latest Blocks list. You should see the delegate username on it.

### Review checklist
- The PR solves #555 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
