### PR TITLE
Show supply percentage in top accounts page in mobile - Subtask #537

### DIFF
--- a/src/components/top-accounts/top-accounts.html
+++ b/src/components/top-accounts/top-accounts.html
@@ -38,8 +38,8 @@
 									<a href="/address/{{address.address}}">{{address.address}}</a>
 								</td>
 								<td class="right-padding-xs text-right">
-									<span class="hidden-sm hidden-md hidden-lg">{{address.balance | currency:$root.currency:$root.decimalPlaces:0}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
-									<span class="hidden-xs">{{address.balance | currency:$root.currency:$root.decimalPlaces:2}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
+									<span class="visible-xs">{{address.balance | currency:$root.currency:0}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
+									<span class="hidden-xs">{{address.balance | currency:$root.currency:$root.decimalPlaces}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
 								</td>
 								<td class="right-padding-s text-right hidden-xs">{{address.balance | supplyPercent:$root.blockStatus.supply}}%</td>
 								<td class="right-padding-m right-padding-l double text-right hidden-xs hidden-sm">

--- a/src/components/top-accounts/top-accounts.html
+++ b/src/components/top-accounts/top-accounts.html
@@ -27,7 +27,7 @@
 								<th class="left-padding-s left-padding-m left-padding-l double hidden-xs" width="5%">Rank</th>
 								<th class="left-padding-xs address-cell">Address</th>
 								<th class="right-padding-xs text-right">~ Balance</th>
-								<th class="right-padding-s text-right hidden-xs">Supply</th>
+								<th class="right-padding-s text-right">Supply</th>
 								<th class="right-padding-m right-padding-l double text-right hidden-xs hidden-sm">Owner</th>
 							</tr>
 						</thead>
@@ -35,13 +35,14 @@
 							<tr data-ng-repeat="address in vm.topAccounts.results track by $index">
 								<td class="left-padding-s left-padding-m left-padding-l double hidden-xs">{{$index + 1}}</td>
 								<td class="left-padding-xs address-cell">
-									<a href="/address/{{address.address}}">{{address.address}}</a>
+									<a href="/address/{{address.address}}" class="visible-xs">{{address.address | middleEllipsis:5}}</a>
+									<a href="/address/{{address.address}}" class="hidden-xs">{{address.address}}</a>
 								</td>
 								<td class="right-padding-xs text-right">
 									<span class="visible-xs">{{address.balance | currency:$root.currency:0}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
 									<span class="hidden-xs">{{address.balance | currency:$root.currency:$root.decimalPlaces}} <span class="text-muted">{{$root.currency.symbol}}</span></span>
 								</td>
-								<td class="right-padding-s text-right hidden-xs">{{address.balance | supplyPercent:$root.blockStatus.supply}}%</td>
+								<td class="right-padding-s text-right">{{address.balance | supplyPercent:$root.blockStatus.supply}}%</td>
 								<td class="right-padding-m right-padding-l double text-right hidden-xs hidden-sm">
 									<span class="owner-name">{{address.knowledge.owner}}</span>
 									<span class="owner-desc text-muted">{{address.knowledge.description}}</span>

--- a/src/filters/currency.js
+++ b/src/filters/currency.js
@@ -27,7 +27,7 @@ AppFilters.filter('currency', (numberFilter, liskFilter) => (amount, currency, d
 	}
 
 	const decimals = (currency.symbol === 'LSK' || currency.symbol === 'BTC') ? decimalPlaces : 2;
-	if (decimals && lisk > 0) {
+	if (typeof decimals === 'number' && lisk > 0) {
 		return numberFilter((lisk * factor), decimals);
 	}
 	return numberFilter((lisk * factor), 8).replace(/\.?0+$/, '');

--- a/src/filters/middle-ellipsis.js
+++ b/src/filters/middle-ellipsis.js
@@ -13,25 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import './filters.module';
-import './alter-word-separation';
-import './approval';
-import './currency';
-import './epoch-stamp';
-import './fiat';
-import './forging-time';
-import './lisk';
-import './net-hash';
-import './proposal';
-import './round';
-import './split';
-import './start-from';
-import './supply-percent';
-import './time-ago';
-import './time-span';
-import './time-stamp';
-import './tx-recipient';
-import './tx-sender';
-import './tx-type';
-import './votes';
-import './middle-ellipsis';
+import AppFilters from './filters.module';
+
+AppFilters.filter('middleEllipsis', () => (str, visibleDigits) =>
+	`${str.substr(0, visibleDigits)}...${str.substr(str.length - visibleDigits)}`);


### PR DESCRIPTION
### What was the problem?
 - Open up space for supplies in top account page in mobile.
 
### How did I fix it?
 - created the middleEllipsis filter to hide a part of LiskIDs.
 - modified the currency filter to only show up to 2 floating digits for top accounts.

### Review checklist
- The PR solves #537 
- All new code follows best practices
