### PR TITLE
Fix number of trades - Closes #569

### DIFF
--- a/lib/api/candles.js
+++ b/lib/api/candles.js
@@ -145,7 +145,7 @@ module.exports = function (app) {
 				liskVolume: _.reduce(results[0], (memo, t) =>
 					(memo + parseFloat(t.liskVolume)), 0.0).toFixed(8),
 				numTrades: _.reduce(results[0], (memo, t) =>
-					(memo + parseInt(t.numTrades, 10)), 0),
+					(memo + (parseInt(t.numTrades, 10) || 0)), 0),
 			};
 
 			statistics = {


### PR DESCRIPTION
### What was the problem?
The exchange response doesn't set numTrades attribute when there is no trade and it causes parseInt to return NaN

### How did I fix it?
I set numTrades equal to 0 when NaN

### How to test it?
Access `/marketWatcher`. You should see the Num of Trades

### Review checklist
- The PR solves #569 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
