### PR TITLE
Use core epoch - Closes #534

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -59,4 +59,9 @@ module.exports = (app) => {
 		const data = services.common.version();
 		return res.json(data);
 	});
+
+	app.get('/api/nodeConstants', (req, res) => {
+		const data = services.common.nodeConstants();
+		return res.json(data);
+	});
 };

--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.exchange = new utils.exchange(config);
 app.knownAddresses = new utils.knownAddresses(app, config, client);
 app.orders = new utils.orders(config, client);
 
-app.set('version', '0.3');
+app.set('version', packageJson.version);
 app.set('strict routing', true);
 app.set('lisk address', `http://${config.lisk.host}:${config.lisk.port}${config.lisk.apiPath}`);
 app.set('freegeoip address', `http://${config.freegeoip.host}:${config.freegeoip.port}`);

--- a/app.js
+++ b/app.js
@@ -186,7 +186,7 @@ app.get('*', (req, res, next) => {
 	return next();
 });
 
-const getNodeVersion = () => new Promise((success, error) => {
+const getNodeConstants = () => new Promise((success, error) => {
 	request.get({
 		url: `${app.get('lisk address')}/node/constants`,
 		json: true,
@@ -195,6 +195,7 @@ const getNodeVersion = () => new Promise((success, error) => {
 			return error({ success: false, error: err.message });
 		} else if (response.statusCode === 200) {
 			if (body && body.data) {
+				app.set('nodeConstants', body.data);
 				return success({ success: true, version: body.data.version });
 			}
 		}
@@ -207,7 +208,7 @@ const status = { NOT_RUNNING: 0, OK: 1 };
 let serverStatus = status.NOT_RUNNING;
 
 const startServer = (cb) => {
-	getNodeVersion().then((result) => {
+	getNodeConstants().then((result) => {
 		logger.info(`Connected to the node ${app.get('lisk address')}, Lisk Core version ${result.version}`);
 		const server = app.listen(app.get('port'), app.get('host'), (err) => {
 			if (err) {

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -14,9 +14,9 @@
  *
  */
 module.exports = function (app, api) {
-	this.version = function () {
-		return { version: app.get('version') };
-	};
+	this.nodeConstants = () => app.get('nodeConstants');
+	this.version = () => ({ version: app.get('version') });
+
 	const exchange = app.exchange;
 	const addressReg = /^[0-9]{2,21}[L|l]$/;
 	const publicKeyReg = /^[0-9a-f]{64}$/;

--- a/src/app/run.js
+++ b/src/app/run.js
@@ -41,4 +41,10 @@ App.run((
 		$location.hash($stateParams.scrollTo);
 		$anchorScroll();
 	});
+
+	$http.get('/api/nodeConstants').then((result) => {
+		if (result && result.data) {
+			$rootScope.nodeConstants = result.data;
+		}
+	});
 });

--- a/src/filters/epoch-stamp.js
+++ b/src/filters/epoch-stamp.js
@@ -15,6 +15,10 @@
  */
 import AppFilters from './filters.module';
 
-AppFilters.filter('epochStamp', () => d => new Date(
-	(((Date.UTC(2016, 4, 24, 17, 0, 0, 0) / 1000) + d) * 1000),
-));
+AppFilters.filter('epochStamp', $rootScope => (d) => {
+	const epoch = $rootScope.nodeConstants && $rootScope.nodeConstants.epoch ?
+		$rootScope.nodeConstants.epoch :
+		'2016-05-24T17:00:00.000Z';
+
+	return new Date((((Date.parse(epoch) / 1000) + d) * 1000));
+});


### PR DESCRIPTION
### What was the problem?
Genesis epoch was hard-coded to mainnet value

### How did I fix it?
I've created an api endpoint to return core constants and use it on epochStamp angular filter

### How to test it?
Change the `epochTime` attribute on `helpers/constants.js` core codebase, reload the application and check any transaction timestamp displayed on explorer

### Review checklist
- The PR solves #534 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
