### PR TITLE
Duplicated peers fix - Closes #594

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -269,7 +269,7 @@ module.exports = function (app) {
 		this.locations = locator;
 
 		this.url = (offset, limit) =>
-			setOffsetAndLimit('/peers?', offset, limit);
+			setOffsetAndLimit('/peers?sort=version:desc', offset, limit);
 
 		const osBrands = { unknown: 0, darwin: 1, linux: 2, freebsd: 3 };
 
@@ -281,6 +281,8 @@ module.exports = function (app) {
 			return { name, group };
 		};
 
+		this.isPeerPresent = peer => peer && peer.ip && (this.ips.indexOf(peer.ip) > -1);
+
 		this.collect = function (peers, cb) {
 			let i = 0;
 			const self = this;
@@ -289,12 +291,12 @@ module.exports = function (app) {
 
 			async.doUntil(
 				(next) => {
-					self.process(peers[i], next);
+					if (this.isPeerPresent(peers[i])) next();
+					else self.process(peers[i], next);
 				},
 				() => {
 					i += 1;
-
-					return (i + 1) > peers.length;
+					return i >= peers.length;
 				},
 				(err) => {
 					if (err) {
@@ -401,7 +403,6 @@ module.exports = function (app) {
 			},
 			() => {
 				offset += limit;
-
 				return found || (offset > peers.maxOffset);
 			},
 			(err) => {

--- a/test/api/statistics.js
+++ b/test/api/statistics.js
@@ -66,6 +66,10 @@ describe('Statistics API', () => {
 			'totalFee');
 	}
 
+	function hasDuplicates(array) {
+		return (new Set(array.map(o => o.ip))).size !== array.length;
+	}
+
 	/* Define api endpoints to test */
 	describe('GET /api/statistics/getLastBlock', () => {
 		it('should be ok', (done) => {
@@ -96,7 +100,6 @@ describe('Statistics API', () => {
 		}).timeout(60000);
 	});
 
-
 	describe('GET /api/statistics/getPeers', () => {
 		it('should be ok', (done) => {
 			getPeers((err, res) => {
@@ -104,6 +107,13 @@ describe('Statistics API', () => {
 				node.expect(res.body).to.have.property('list');
 				checkPeersList(res.body.list.connected);
 				checkPeersList(res.body.list.disconnected);
+				done();
+			});
+		});
+
+		it('should not contain duplicated IPs', (done) => {
+			getPeers((err, res) => {
+				node.expect(hasDuplicates(res.body.list.connected)).to.be.equal(false);
 				done();
 			});
 		});


### PR DESCRIPTION
### What was the problem?
Duplicated peers being listed on Network Monitor

### How did I fix it?
I've added `sort` option to peers query in order to make the response consistent.
Additionally I've added a check before processing the peer array.

### How to test it?
A test was added to cater for this scenario.
Run `npm run test`

### Review checklist
- The PR solves #594
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
