### PR TITLE
Add additional data to transaction page - Closes #577

### DIFF
--- a/src/components/transactions/transactions.html
+++ b/src/components/transactions/transactions.html
@@ -99,6 +99,10 @@
 					</td>
 					<td data-ng-if="!vm.tx.blockId" class="text-right">Unconfirmed</td>
 				</tr>
+				<tr data-ng-if="vm.tx.type == 0 && vm.tx.asset && vm.tx.asset.data">
+					<td><strong>Additional Data</strong></td>
+					<td class="text-right">{{vm.tx.asset.data}}</td>
+				</tr>
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
### What was the problem?
Additional data for transactions type 0 not showing on transaction page

### How did I fix it?
Added a new row on Summary table of transaction page

### How to test it?
Connect Explorer to betanet and access `/tx/15429910859603286865`

### Review checklist
- The PR solves #577 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
