### PR TITLE
Next forgers number incorrect - Closes #520

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -244,16 +244,34 @@ module.exports = function (app) {
 	};
 
 	this.getNextForgers = function (query, error, success) {
-		request.get({
-			url: `${app.get('lisk address')}/api/delegates/getNextForgers?limit=101`,
-			json: true,
-		}, (err, response, body) => {
-			if (err || response.statusCode !== 200) {
-				return error({ success: false, error: (err || 'Response was unsuccessful') });
-			} else if (body.success === true) {
-				return success({ success: true, delegates: body.delegates });
-			}
-			return error({ success: false, error: body.error });
+		const getHeight = (cb) => {
+			request.get({
+				url: `${app.get('lisk address')}/api/blocks/getHeight`,
+				json: true,
+			}, (err, response, body) => {
+				if (err || response.statusCode !== 200) {
+					return error({ success: false, error: (err || 'Response was unsuccessful') });
+				} else if (body.success === true) {
+					return cb(body.height);
+				}
+				return error({ success: false, error: body.error });
+			});
+		};
+
+		async.waterfall([getHeight], (height) => {
+			const roundLength = 101;
+			const limit = roundLength - ((height - 1) % roundLength);
+			request.get({
+				url: `${app.get('lisk address')}/api/delegates/getNextForgers?limit=${limit}`,
+				json: true,
+			}, (err, response, body) => {
+				if (err || response.statusCode !== 200) {
+					return error({ success: false, error: (err || 'Response was unsuccessful') });
+				} else if (body.success === true) {
+					return success({ success: true, delegates: body.delegates });
+				}
+				return error({ success: false, error: body.error });
+			});
 		});
 	};
 


### PR DESCRIPTION
### What was the problem?
The next forgers list contained forgers that are not supposed to forge in a current round.

### How did I fix it?
Next forgers limit dynamically adjusted to remaining blocks number in a round.

### How to test it?
Go to the Delegate Monitor

### Review checklist
- The PR solves #520
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
