### PR TITLE
630 total forged decimal places - Closes #630 

### DIFF
--- a/features/delegateMonitor.feature
+++ b/features/delegateMonitor.feature
@@ -41,7 +41,7 @@ Feature: Delegate Monitor
     And I should see "total forged" element with content that matches:
       """
       TOTAL FORGED \(LSK\)
-      \d{1,3},\d{3}\.\d{8}
+      \d{1,3},\d{3}\
       between 101 active delegates
       """
     And I should see "best forger" element with content that matches:

--- a/src/components/delegate-monitor/delegate-monitor.html
+++ b/src/components/delegate-monitor/delegate-monitor.html
@@ -95,7 +95,7 @@
 							<div class="pull-left total-forged">
 								<p class="small-title">Total Forged <span class="text-muted">({{$root.currency.symbol}})</span></p>
 								<p class="big-details">
-									<span class="lisk">{{vm.totalForged || 0 | currency:$root.currency:$root.decimalPlaces}}</span>
+									<span class="lisk">{{vm.totalForged || 0 | currency:$root.currency:0}}</span>
 								</p>
 								<p class="text-muted total-active">between {{vm.totalActive || 0 }} active delegates</p>
 							</div>


### PR DESCRIPTION
### What was the problem?
Total Forged on Delegate Monitor was showing decimal places

### How did I fix it?
I've set the decimal places param to be zero on `currency` filter

### How to test it?
Access `delegateMonitor`

### Review checklist
- The PR solves #630 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
