### PR TITLE
Remove letter-spacing style from network bar

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -225,7 +225,6 @@
 .navbar-fixed-top .network-status span {
   color: #ccc;
   line-height: 24px;
-  letter-spacing: 1px;
   width: auto;
   float: none;
 }


### PR DESCRIPTION
### What was the problem?
Undesired `letter-spacing` attribute on network bar

### How did I fix it?
CSS style attribute was removed

### Review checklist
- The PR solves #INSERT_ISSUE_NUMBER
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
