### PR TITLE
Make network bar full width - Closes #636

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -198,6 +198,7 @@
   width: 100%;
   position: relative;
   z-index: 1;
+  background-color: rgb(1, 56, 115);
 }
 
 .navbar-fixed-top .network-status .flex-container {


### PR DESCRIPTION
### What was the problem?
Network status bar limited to the container width

### How did I fix it?
Added background to div to match the bar color

### Review checklist
- The PR solves #636 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
