### PR TITLE
Remove opacity network bar - Closes #637

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -202,7 +202,7 @@
 }
 
 .navbar-fixed-top .network-status .flex-container {
-  background: rgba(1, 56, 115, 0.81);
+  background: rgb(1, 56, 115);
   padding: 8px 12px;
   border-radius: 0 0 3px 3px;
   margin: 0;


### PR DESCRIPTION
### What was the problem?
Opacity in network status bar 

### How did I fix it?
Used `rgb` rather than `rgba` style

### How to test it?
Scroll the page and check the network status bar

### Review checklist
- The PR solves #637 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
