### PR TITLE
Always close currency dropdown after selecting - Closes #649

### DIFF
--- a/src/components/currency-selector/currency-selector.directive.js
+++ b/src/components/currency-selector/currency-selector.directive.js
@@ -26,6 +26,8 @@ AppCurrency.directive('currencySelector', ($rootScope, $timeout) => {
 	const CurrencySelectorCtrl = function () {
 		this.setCurrency = (currency) => {
 			$rootScope.currency.symbol = currency;
+			$rootScope.isCollapsed = true;
+
 			if (localStorage) {
 				localStorage.setItem('lisk_explorer-currency', currency);
 			}


### PR DESCRIPTION
### What was the problem?
Currency dropdown not closing after selected on mobile view

### How did I fix it?
Actively setting `isCollapsed` to true when changing currencies

### How to test it?
Access the application on mobile view and change currencies

### Review checklist
- The PR solves #649 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
