### PR TITLE
Show search input when not on mobile - Closes #596

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -1,32 +1,24 @@
 Feature: Top menu
   Scenario: should allow to find a block by id
     Given I'm on page "/"
-    When I click "glyphicon search" in "desktop search" div
-    And I wait 0.5 seconds
     And I fill in "6524861224470851795" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     Then I should be on page "/block/6524861224470851795"
 
   Scenario: should allow to find a transaction by id
     Given I'm on page "/"
-    When I click "glyphicon search" in "desktop search" div
-    And I wait 0.5 seconds
     And I fill in "1465651642158264047" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     Then I should be on page "/tx/1465651642158264047"
 
   Scenario: should allow to find an account by address
     Given I'm on page "/"
-    When I click "glyphicon search" in "desktop search" div
-    And I wait 0.5 seconds
     And I fill in "16313739661670634666L" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     Then I should be on page "/address/16313739661670634666L"
 
   Scenario: should allow to find a delegate by username
     Given I'm on page "/"
-    When I click "glyphicon search" in "desktop search" div
-    And I wait 0.5 seconds
     And I fill in "genesis_17" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     And I wait 1 seconds
@@ -35,8 +27,6 @@ Feature: Top menu
 
   Scenario: should show an error message on invalid input
     Given I'm on page "/"
-    When I click "glyphicon search" in "desktop search" div
-    And I wait 0.5 seconds
     And I fill in "invalid" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     Then I should see "No matching records found!" in ".desktop-search .empty-result-title" html element
@@ -87,6 +77,7 @@ Feature: Top menu
       | Id                 | Timestamp                 | Sender      | Recipient             | Amount                     | Fee               |
       |--------------------|---------------------------|-------------|-----------------------|----------------------------|-------------------|
       | 292176566870988581 | /2017\/06\/19 \d\d:18:09/ | standby_301 | 18234943547133247982L | /\d+(,\d{3})?(\.\d+)? RUB/ | /\d+(\.\d+)? RUB/ |
+
   Scenario: should allow to switch currency to LSK
     Given I'm on page "/"
     When I click "LSK menu"

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -139,7 +139,7 @@
 }
 
 .search-box.active {
-  width: 305px !important;
+  width: 360px !important;
 }
 
 .search-box.active input#search {
@@ -158,7 +158,7 @@
   font-family: 'Roboto', 'Ubuntu', sans-serif;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .search-box {
     margin-top: 7px;
   }

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -38,7 +38,7 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<search class="visible-xs mobile-search" />
+				<search class="visible-xs mobile-search" mobile-view="true" />
 				<div class="navbar-collapse main-menu" data-ng-class="{collapse: $root.isCollapsed}">
 					<ul class="nav navbar-nav navbar-right">
 							<currency-selector />

--- a/src/components/search/search.directive.js
+++ b/src/components/search/search.directive.js
@@ -77,6 +77,10 @@ AppSearch.directive('search', ($stateParams, $location, $timeout, Global, $http)
 		link: SearchLink,
 		controller: SearchCtrl,
 		controllerAs: 'sch',
+		scope: {
+			mobileView: '@',
+		},
+		bindToController: true,
 		template,
 	};
 });

--- a/src/components/search/search.html
+++ b/src/components/search/search.html
@@ -15,11 +15,11 @@
  *
  */
 -->
-<form role="search" data-ng-submit="sch.search()" data-ng-class="{'loading': sch.loading, 'active': src.activeForm}" class='search-box'>
+<form role="search" data-ng-submit="sch.search()" data-ng-class="{'loading': sch.loading, 'active': !sch.mobileView || sch.activeForm}" class='search-box'>
 	<div class="wrapper" data-ng-class="{'has-error': sch.badQuery}">
 		<input id="search" type="text" class="input search" data-ng-model="sch.q" placeholder="Find a transaction, address, delegate or block"
 			data-ng-submit="sch.search()" data-ng-blur="sch.hideSuggestion()" autocomplete="off" />
-		<span class="glyphicon" aria-hidden="true" data-ng-click="src.activeForm = !src.activeForm" data-ng-class="{'glyphicon-remove': src.activeForm, 'glyphicon-search': !src.activeForm}"></span>
+		<span class="glyphicon" aria-hidden="true" data-ng-click="sch.activeForm = !sch.activeForm" data-ng-class="{'glyphicon-remove': sch.mobileView && sch.activeForm, 'glyphicon-search': !sch.mobileView || !sch.activeForm}"></span>
 		<div class="search-suggestion-list list-group"
 			ng-if="sch.showingResults && sch.results">
 			<a href="/address/{{result.address}}" class="search-suggestion-item list-group-item list-group-item-action flex-column align-items-start"


### PR DESCRIPTION
### What was the problem?
User required two clicks to perform a serch

### How did I fix it?
As discussed with the team, I changed the behaviour to display the search input when there is enough space for it (when not on mobile view)

### How to test it?
Check the search bar on desktop and mobile views

### Review checklist
- The PR solves #596
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
