### PR TITLE
Firefox text-icon wrap fix - Closes #671

### DIFF
--- a/src/shared/transaction-item/transaction-item.html
+++ b/src/shared/transaction-item/transaction-item.html
@@ -15,7 +15,7 @@
  *
  */
 -->
-<td data-title="Transaction ID" class="text-nowrap left-padding-m left-padding-l double">
+<td data-title="Transaction ID" class="left-padding-m left-padding-l double">
 	<span class="hidden-md">
 		<a class="txid hidden-md" href="/tx/{{tx.id}}">{{tx.id}}</a>
 		<span class="btn-copy pull-right" clip-copy="tx.id"></span>


### PR DESCRIPTION
### What was the problem?
The copy icon was wrapped after the ID in the transaction table.

### How did I fix it?
I've removed the `text-nowrap` attrbute for that column.

### How to test it?

### Review checklist
- The PR solves #671
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
