### PR TITLE
Change tooltip position avoiding undesired margins - Closes #670

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -948,6 +948,7 @@ qrcode + span {
   display: inline-block;
   outline: none;
   border-radius: 5px;
+  margin-left: 3px;
   text-align: center;
   cursor: pointer;
 }
@@ -970,8 +971,8 @@ qrcode + span {
 
 .btn-copy .tooltip {
   display: block;
-  margin-left: 16px;
-  margin-top: -22px;
+  margin-left: -24px;
+  margin-top: -64px;
   opacity: 0;
   pointer-events: none;
 }
@@ -983,6 +984,11 @@ qrcode + span {
 
 .tooltip.right .tooltip-arrow {
   border-right-color: #0288d1;
+}
+
+.btn-copy .tooltip.top .tooltip-arrow {
+  border-top-color: #0288d1;
+  left: 30px;
 }
 
 .btn-copy.active .tooltip { opacity: 1; }

--- a/src/components/address/address.html
+++ b/src/components/address/address.html
@@ -64,13 +64,14 @@
 						<tr>
 							<td class="left-padding-xs left-padding-s left-padding-l"><strong>Address</strong></td>
 							<td class="right-padding-xs right-padding-s right-padding-l text-right">
-								<span>{{vm.address.address}}&nbsp;<span class="btn-copy" clip-copy="vm.address.address"></span></span>
+								<span>{{vm.address.address}}</span>
+								<span class="btn-copy" clip-copy="vm.address.address"></span>
 							</td>
 						</tr>
 						<tr class="hidden-xs">
 							<td class="left-padding-s left-padding-l"><strong>Public Key</strong></td>
-							<td class="text-right" data-ng-if="vm.address.publicKey">
-								{{vm.address.publicKey}}&nbsp;
+							<td class="right-padding-s right-padding-l text-right" data-ng-if="vm.address.publicKey">
+								<span>{{vm.address.publicKey}}</span>
 								<span class="btn-copy" clip-copy="vm.address.publicKey"></span>
 							</td>
 							<td class="right-padding-s right-padding-l text-right" data-ng-if="!vm.address.publicKey">

--- a/src/directives/clip-copy.js
+++ b/src/directives/clip-copy.js
@@ -19,24 +19,29 @@ import AppTools from '../app/app-tools.module';
 AppTools.directive('clipCopy', () => ({
 	restric: 'A',
 	scope: { clipCopy: '=clipCopy' },
-	template: '<div class="tooltip fade right in"><div class="tooltip-arrow"></div><div class="tooltip-inner">{{tooltipText}}</div></div>',
-	link(scope, elm) {
-		scope.tooltipText = 'Copied!';
+	template: '<div data-ng-if="tooltipText" class="tooltip fade top in"><div class="tooltip-arrow"></div><div class="tooltip-inner">{{tooltipText}}</div></div>',
+	link(scope, elm, attrs) {
 		const clip = new Clipboard(elm[0], {
-			// eslint-disable-next-line no-unused-vars
-			text: target => scope.clipCopy,
+			text: () => scope.clipCopy,
 		});
+
 		clip.on('success', () => {
+			scope.tooltipText = attrs.tooltipLabel || 'Copied!';
+			scope.$apply();
 			elm.addClass('active');
 		});
+
 		elm.on('mouseleave', () => {
 			elm.removeClass('active');
+			scope.tooltipText = null;
 		});
+
 		clip.on('error', () => {
 			scope.tooltipText = 'Press Ctrl+C to copy!';
 			scope.$apply();
 			elm.addClass('active');
 		});
+
 		scope.$on('$destroy', () => clip.destroy());
 	},
 }));

--- a/src/directives/clip-copy.js
+++ b/src/directives/clip-copy.js
@@ -42,6 +42,14 @@ AppTools.directive('clipCopy', () => ({
 			elm.addClass('active');
 		});
 
+		if (attrs.onHover) {
+			elm.on('mouseenter', () => {
+				scope.tooltipText = attrs.onHover;
+				scope.$apply();
+				elm.addClass('active');
+			});
+		}
+
 		scope.$on('$destroy', () => clip.destroy());
 	},
 }));

--- a/src/shared/transaction-item/transaction-item.html
+++ b/src/shared/transaction-item/transaction-item.html
@@ -17,11 +17,11 @@
 -->
 <td data-title="Transaction ID" class="text-nowrap left-padding-m left-padding-l double">
 	<span class="hidden-md">
-		<a class="txid hidden-md" href="/tx/{{tx.id}}">{{tx.id}}</a>
-		<span class="btn-copy pull-right" clip-copy="tx.id"></span>
+		<a class="txid" href="/tx/{{tx.id}}">{{tx.id}}</a>
+		<span class="btn-copy pull-right right-padding-xs right-padding-s" clip-copy="tx.id"></span>
 	</span>
 	<span class="visible-md">
-		<span class="btn-copy" clip-copy="tx.id" data-uib-tooltip="{{tx.id}}"></span>
+		<span class="btn-copy" clip-copy="tx.id" data-tooltip-label="{{tx.id}}"></span>
 	</span>
 </td>
 <td data-title="Date">

--- a/src/shared/transaction-item/transaction-item.html
+++ b/src/shared/transaction-item/transaction-item.html
@@ -21,7 +21,7 @@
 		<span class="btn-copy pull-right right-padding-xs right-padding-s" clip-copy="tx.id"></span>
 	</span>
 	<span class="visible-md">
-		<span class="btn-copy" clip-copy="tx.id" data-tooltip-label="{{tx.id}}"></span>
+		<span class="btn-copy" clip-copy="tx.id" data-on-hover="{{tx.id}}"></span>
 	</span>
 </td>
 <td data-title="Date">


### PR DESCRIPTION
### What was the problem?
Unexpected horizontal scrollbar on Address page when on mobile view due `tooltip` element

### How did I fix it?
I've changed the tooltip position and added `padding` to the right of the table

### How to test it?
Access Address page on mobile view

### Review checklist
- The PR solves #670 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
