### PR TITLE
 Automatically focus on searchbox after expanding - Closes #669

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -142,6 +142,12 @@
   width: 360px !important;
 }
 
+@media (max-width: 1024px) {
+  .search-box.active {
+    width: 340px !important;
+  }
+}
+
 .search-box.active input#search {
   width: calc(100% - 52px) !important;
 }

--- a/src/components/search/search.directive.js
+++ b/src/components/search/search.directive.js
@@ -39,6 +39,13 @@ AppSearch.directive('search', ($stateParams, $location, $timeout, Global, $http)
 			}, 200);
 		};
 
+		this.expandInput = () => {
+			this.activeForm = !this.activeForm;
+			$timeout(() => {
+				document.getElementById('search').focus();
+			}, 500);
+		};
+
 		this.hideSuggestion = () => {
 			_resetSearch();
 		};

--- a/src/components/search/search.html
+++ b/src/components/search/search.html
@@ -19,7 +19,7 @@
 	<div class="wrapper" data-ng-class="{'has-error': sch.badQuery}">
 		<input id="search" type="text" class="input search" data-ng-model="sch.q" placeholder="Find a transaction, address, delegate or block"
 			data-ng-submit="sch.search()" data-ng-blur="sch.hideSuggestion()" autocomplete="off" />
-		<span class="glyphicon" aria-hidden="true" data-ng-click="sch.activeForm = !sch.activeForm" data-ng-class="{'glyphicon-remove': sch.mobileView && sch.activeForm, 'glyphicon-search': !sch.mobileView || !sch.activeForm}"></span>
+		<span class="glyphicon" aria-hidden="true" data-ng-click="sch.expandInput()" data-ng-class="{'glyphicon-remove': sch.mobileView && sch.activeForm, 'glyphicon-search': !sch.mobileView || !sch.activeForm}"></span>
 		<div class="search-suggestion-list list-group"
 			ng-if="sch.showingResults && sch.results">
 			<a href="/address/{{result.address}}" class="search-suggestion-item list-group-item list-group-item-action flex-column align-items-start"


### PR DESCRIPTION
### What was the problem?
To search in mobile devices, we need to click on the search icon and then click on search input to focus onto.  while it should be possible with a single click.

### How did I fix it?
Tweaked the directive to automatically focus after the input expanded.

### Review checklist
- The PR solves #669 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
