### PR TITLE
List disconnected peers on Network Monitor - Closes #623

### DIFF
--- a/features/networkMonitor.feature
+++ b/features/networkMonitor.feature
@@ -5,6 +5,7 @@ Feature: Network Monitor
       """
       CONNECTED PEERS
       \d+  /  \d+
+      \d+ disconnected peers
       """
     And I should see "Home Network Monitor" in "breadcrumb" element
     And I should see "last block loaded" element with content that matches:

--- a/src/components/network-monitor/network-monitor.html
+++ b/src/components/network-monitor/network-monitor.html
@@ -34,6 +34,7 @@
 									<span class="text-muted">&nbsp;/&nbsp;</span>
 									<span class="total-peers">{{vm.counter.total || 0}}</span>
 								</p>
+								<p class="text-muted disconnected-peers">{{vm.counter.disconnected || 0}} disconnected peers</p>
 							</div>
 						</div>
 					</div>
@@ -232,8 +233,16 @@
 	</div>
 	<div class="row">
 		<div class="col-xs-12 big-info peers">
-			<h2 class="horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">Connected peers <br /></h2>
-			<peers peers="vm.peers.connected"></peers>
+			<uib-tabset justified="true" class="peers">
+				<uib-tab>
+					<uib-tab-heading><span class="glyphicon glyphicon-ok-sign"></span> Connected Peers</uib-tab-heading>
+					<peers peers="vm.peers.connected"></peers>
+				</uib-tab>
+				<uib-tab>
+					<uib-tab-heading><span class="glyphicon glyphicon-remove-sign"></span> Disconnected Peers</uib-tab-heading>
+					<peers peers="vm.peers.disconnected"></peers>
+				</uib-tab>
+			</uib-tabset>
 		</div>
 	</div>
 </div>

--- a/src/components/network-monitor/network-monitor.service.js
+++ b/src/components/network-monitor/network-monitor.service.js
@@ -269,7 +269,8 @@ const NetworkMonitor = function (vm) {
 
 		return {
 			connected: peers.connected.length,
-			total: peers.connected.length,
+			disconnected: peers.disconnected.length,
+			total: peers.connected.length + peers.disconnected.length,
 			platforms: platforms.detected(),
 			versions: versions.detected(),
 			heights: heights.detected(),
@@ -281,6 +282,7 @@ const NetworkMonitor = function (vm) {
 		// default sort in sort by version
 		vm.peers = {
 			connected: peers.list.connected,
+			disconnected: peers.list.disconnected,
 		};
 
 		vm.counter = this.counter(vm.peers);


### PR DESCRIPTION
### What was the problem?
Disconnected peers not showing on Network Monitor

### How did I fix it?
Added disconnected peers list back

### How to test it?
Check `/networkMonitor`

### Review checklist
- The PR solves #623
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
