### PR TITLE
Make map area scrollable on mouse/touch dragging - Closes #694 #693

### DIFF
--- a/src/components/network-monitor/network-monitor.service.js
+++ b/src/components/network-monitor/network-monitor.service.js
@@ -51,7 +51,15 @@ const sortByVersion = (p1, p2) => {
 
 const NetworkMap = function () {
 	this.markers = {};
-	this.options = { center: leaflet.latLng(40, 0), zoom: 1, minZoom: 1, maxZoom: 10 };
+	this.options = {
+		center: leaflet.latLng(40, 0),
+		zoom: 1,
+		minZoom: 1,
+		maxZoom: 10,
+		dragging: !leaflet.Browser.mobile,
+		scrollWheelZoom: false,
+		tap: false,
+	};
 	this.map = leaflet.map('map', this.options);
 	this.cluster = leaflet.markerClusterGroup({ maxClusterRadius: 50 });
 


### PR DESCRIPTION
### What was the problem?
The page won't scroll when mouse/touch was positioned over the map area

### How did I fix it?
I've disabled `dragging`, `scrollWheelZoom` and `tap` options on leaflet library

### How to test it?
Access `/networkMonitor` on desktop and mobile version and scrolls the page up and down over the map area

### Review checklist
- The PR solves #694 #693 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
