### PR TITLE
Restore redis connection - Closes #696

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -30,5 +30,17 @@ module.exports = function (config) {
 		});
 	}
 
+	client.on('connect', () => {
+		logger.info(`Redis: Connected to ${config.redis.host}:${config.redis.port}`);
+	});
+
+	client.on('error', (err) => {
+		logger.error(`Redis: ${err.message}`);
+	});
+
+	client.on('reconnecting', () => {
+		logger.warn('Redis: reconnecting...');
+	});
+
 	return client;
 };


### PR DESCRIPTION
### What was the problem?
Disconnected Redis caused backend crash.

### How did I fix it?
The Redis client tries to reconnect after a connection with Redis server is lost.

### How to test it?
Run the process and try to stop and restart Redis server.

### Review checklist
- The PR solves #696
- All new code follows best practices
