### PR TITLE
E2E tests enabled - Closes #394

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,11 +91,19 @@ pipeline {
 				'''
 			}
 		}
-		stage ('Run tests') {
+		stage ('Run API tests') {
 			steps {
 				sh '''
 				sed -i -r -e "s/6040/$EXPLORER_PORT/" test/node.js
 				npm run test
+				'''
+			}
+		}
+		stage ('Run E2E tests') {
+			steps {
+				sh '''
+				npm run e2e-test-env-update
+				npm run e2e-test
 				'''
 			}
 		}


### PR DESCRIPTION
### What was the problem?
Failing e2e tests didn't run properly in the Jenkins test environment.

### How did I fix it?
The e2e tests were constantly improved and reached a reasonable level of maturity.
They can be enabled and performed reliable way.

### How to test it?
Run a Jenkins test job.

### Review checklist
- The PR solves #394
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
