### PR TITLE
Re-introduce e2e tests on jenkins - Closes #394

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,21 @@ pipeline {
 				'''
 			}
 		}
+		stage ('Run e2e tests') {
+			steps {
+				sh '''
+				N=${EXECUTOR_NUMBER:-0}
+
+				# End to End test configuration
+				export DISPLAY=:9$N
+				Xvfb :9$N -ac -screen 0 1280x1024x24 &
+				./node_modules/protractor/bin/webdriver-manager start --seleniumPort 443$N &
+
+				# Run E2E Tests
+				npm run e2e -- --params.baseURL http://localhost:604$N
+				'''
+			}
+		}
 	}
 	post {
 		success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
 				'''
 			}
 		}
-		stage ('Run tests') {
+		stage ('Run API tests') {
 			steps {
 				sh '''
 				sed -i -r -e "s/6040/$EXPLORER_PORT/" test/node.js
@@ -99,19 +99,13 @@ pipeline {
 				'''
 			}
 		}
-		stage ('Run e2e tests') {
+		stage ('Run E2E tests') {
 			steps {
-				sh '''
-				N=${EXECUTOR_NUMBER:-0}
-
-				# End to End test configuration
-				export DISPLAY=:9$N
-				Xvfb :9$N -ac -screen 0 1280x1024x24 &
-				./node_modules/protractor/bin/webdriver-manager start --seleniumPort 443$N &
-
-				# Run E2E Tests
-				npm run e2e -- --params.baseURL http://localhost:604$N
-				'''
+				wrap([$class: 'Xvfb']) {
+					sh '''
+					npm run e2e -- --params.baseURL http://localhost:$EXPLORER_PORT
+					'''
+				}
 			}
 		}
 	}

--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -41,7 +41,7 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
 
 	Given('I\'m on page "{pageAddress}"', (pageAddress, callback) => {
 		browser.ignoreSynchronization = true;
-		browser.driver.manage().window().setSize(1200, 1000);
+		browser.driver.manage().window().setSize(1280, 1024);
 		browser.driver.get('about:blank');
 		browser.get(baseURL + pageAddress).then(callback);
 	});

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "test": "./node_modules/.bin/grunt test --verbose",
     "test-live": "npm test -- --auto-watch --no-single-run",
-    "e2e-test": "protractor protractor.conf.js",
-    "e2e-test-env-update": "./node_modules/protractor/bin/webdriver-manager update",
+    "pree2e": "./node_modules/protractor/bin/webdriver-manager update --standalone false --gecko false",
+    "e2e": "protractor protractor.conf.js",
     "eslint": "eslint ./benchmarks ./utils ./libs ./api ./src ./test ./features ./tasks ./*.js ./*.json",
     "eslint-fix": "eslint --fix ./benchmarks ./utils ./libs ./api ./src ./test ./features ./tasks ./*.js",
     "start": "npm run copy-files && webpack -w",


### PR DESCRIPTION
### What was the problem?
E2E tests were skipped due unstability

### How did I fix it?
I've re-introduced e2e tests and added xvfb plugin to jenkins

### How to test it?
Make sure the jenkins checks on this PR are green ;)

### Review checklist
- The PR solves #394 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
