### PR TITLE
Bug - empty transaction list - Closes #712

### DIFF
--- a/lib/api/accounts.js
+++ b/lib/api/accounts.js
@@ -17,6 +17,7 @@ const coreRequest = require('../../utils/core.js');
 const request = require('request');
 const _ = require('underscore');
 const async = require('async');
+const coreUtils = require('../../utils/core.js');
 
 module.exports = function (app) {
 	const knowledge = app.knownAddresses;
@@ -38,7 +39,7 @@ module.exports = function (app) {
 
 		this.getAccount = (address, cb) =>
 			request.get({
-				url: `${app.get('lisk address')}/api/accounts?address=${address}`,
+				url: `${app.get('lisk address')}/api/accounts?address=${coreUtils.parseAddress(address)}`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -90,7 +91,7 @@ module.exports = function (app) {
 				return cb(null, account);
 			}
 			return request.get({
-				url: `${app.get('lisk address')}/api/accounts/delegates/?address=${account.address}`,
+				url: `${app.get('lisk address')}/api/accounts/delegates/?address=${coreUtils.parseAddress(account.address)}`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -139,7 +140,7 @@ module.exports = function (app) {
 			}
 
 			return request.get({
-				url: `${app.get('lisk address')}/api/transactions?recipientId=${account.address}&limit=1`,
+				url: `${app.get('lisk address')}/api/transactions?recipientId=${coreUtils.parseAddress(account.address)}&limit=1`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -159,7 +160,7 @@ module.exports = function (app) {
 			}
 
 			return request.get({
-				url: `${app.get('lisk address')}/api/transactions?senderId=${account.address}&limit=1`,
+				url: `${app.get('lisk address')}/api/transactions?senderId=${coreUtils.parseAddress(account.address)}&limit=1`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -195,9 +196,13 @@ module.exports = function (app) {
 
 	this.getAccount = (params, error, success) => {
 		const account = new Account();
+		let address;
 
-		if (params.address && !account.validAddress(params.address)) {
-			return error({ success: false, error: 'Missing/Invalid address parameter' });
+		if (params.address) {
+			address = coreUtils.parseAddress(params.address);
+			if (!account.validAddress(address)) {
+				return error({ success: false, error: 'Missing/Invalid address parameter' });
+			}
 		}
 
 		if (params.publicKey && !account.validPublicKey(params.publicKey)) {
@@ -206,8 +211,8 @@ module.exports = function (app) {
 
 		return async.waterfall([
 			(cb) => {
-				if (params.address) {
-					account.getAccount(params.address, cb);
+				if (address) {
+					account.getAccount(address, cb);
 				} else if (params.publicKey) {
 					account.getAccountByPublicKey(params.publicKey, cb);
 				} else {

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -17,6 +17,7 @@ const request = require('request');
 const _ = require('underscore');
 const async = require('async');
 const logger = require('../../utils/logger');
+const coreUtils = require('../../utils/core.js');
 
 module.exports = function (app) {
 	const self = this;
@@ -93,7 +94,8 @@ module.exports = function (app) {
 			return cb(null, transaction);
 		}
 
-		const found = getDelegateFromCache(transaction.senderId, tmpDelegateCache);
+		const found = getDelegateFromCache(coreUtils.parseAddress(transaction.senderId),
+			tmpDelegateCache);
 		if (found !== undefined) {
 			transaction.senderDelegate = found;
 			return cb(null, transaction);
@@ -131,7 +133,7 @@ module.exports = function (app) {
 		}
 
 		return request.get({
-			url: `${app.get('lisk address')}/api/accounts/getPublicKey?address=${transaction.recipientId}`,
+			url: `${app.get('lisk address')}/api/accounts/getPublicKey?address=${coreUtils.parseAddress(transaction.recipientId)}`,
 			json: true,
 		}, (err, response, body) => {
 			if (err || response.statusCode !== 200) {
@@ -354,17 +356,18 @@ module.exports = function (app) {
 
 		const directionQueries = [];
 		const baseQuery = `orderBy=timestamp:desc&offset=${param(params.offset, 0)}&limit=${param(params.limit, 100)}`;
+		const address = coreUtils.parseAddress(params.address);
 
 		if (params.direction === 'sent') {
-			directionQueries.push(`${baseQuery}&and:senderId=${params.address}&and:type=0`);
+			directionQueries.push(`${baseQuery}&and:senderId=${address}&and:type=0`);
 		} else if (params.direction === 'received') {
-			directionQueries.push(`${baseQuery}&and:recipientId=${params.address}&and:type=0`);
+			directionQueries.push(`${baseQuery}&and:recipientId=${address}&and:type=0`);
 		} else if (params.direction === 'others') {
 			for (let i = 1; i < 8; i++) {
-				directionQueries.push(`${baseQuery}&and:senderId=${params.address}&and:type=${i}`);
+				directionQueries.push(`${baseQuery}&and:senderId=${address}&and:type=${i}`);
 			}
 		} else if (params.address) {
-			directionQueries.push(`${baseQuery}&and:recipientId=${params.address}&or:senderId=${params.address}`);
+			directionQueries.push(`${baseQuery}&and:recipientId=${address}&or:senderId=${address}`);
 		} else {
 			// advanced search
 			let advanced = '';
@@ -385,14 +388,14 @@ module.exports = function (app) {
 			}
 
 			// If recipientId is the same as senderId, create an extra request for it.
-			if (params.recipientId === params.senderId) {
+			if (coreUtils.parseAddress(params.recipientId) === coreUtils.parseAddress(params.senderId)) {
 				const reqs = directionQueries.length;
 				for (let i = 0; i < reqs; i++) {
 					directionQueries.push(directionQueries[i].replace('senderId', 'recipientId'));
 				}
 			} else if (params.recipientId && !params.senderId) {
 				directionQueries.forEach((directionQuery, index) => {
-					directionQueries[index] = `${directionQuery}&and:recipientId=${params.recipientId}`;
+					directionQueries[index] = `${directionQuery}&and:recipientId=${coreUtils.parseAddress(params.recipientId)}`;
 				});
 			}
 		}

--- a/test/api/accounts.js
+++ b/test/api/accounts.js
@@ -21,8 +21,6 @@ const params = {
 	excessive_offset: '1000000',
 	publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
 	address_lowercase: '16313739661670634666l',
-	address_whitespace1: ' 16313739661670634666L  ',
-	address_whitespace2: ' 163 137 396 616 706 346 66L  ',
 };
 
 describe('Accounts API', () => {
@@ -103,22 +101,6 @@ describe('Accounts API', () => {
 
 		it('using known lowercase address should be ok', (done) => {
 			getAccount(params.address_lowercase, (err, res) => {
-				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
-				done();
-			});
-		});
-
-		it('using known address with whitespaces should be ok', (done) => {
-			getAccount(params.address_whitespace1, (err, res) => {
-				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
-				done();
-			});
-		});
-
-		it('using known address with whitespaces inside should be ok', (done) => {
-			getAccount(params.address_whitespace2, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
 				checkAccount(res.body);
 				done();

--- a/test/api/accounts.js
+++ b/test/api/accounts.js
@@ -20,6 +20,9 @@ const params = {
 	address_delegate: '8273455169423958419L',
 	excessive_offset: '1000000',
 	publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+	address_lowercase: '16313739661670634666l',
+	address_whitespace1: ' 16313739661670634666L  ',
+	address_whitespace2: ' 163 137 396 616 706 346 66L  ',
 };
 
 describe('Accounts API', () => {
@@ -94,6 +97,30 @@ describe('Accounts API', () => {
 			getAccount('999999999L', (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(false);
 				node.expect(res.body).to.have.property('error');
+				done();
+			});
+		});
+
+		it('using known lowercase address should be ok', (done) => {
+			getAccount(params.address_lowercase, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
+				checkAccount(res.body);
+				done();
+			});
+		});
+
+		it('using known address with whitespaces should be ok', (done) => {
+			getAccount(params.address_whitespace1, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
+				checkAccount(res.body);
+				done();
+			});
+		});
+
+		it('using known address with whitespaces inside should be ok', (done) => {
+			getAccount(params.address_whitespace2, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
+				checkAccount(res.body);
 				done();
 			});
 		});

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -19,6 +19,7 @@ const params = {
 	blockId: '6524861224470851795',
 	transactionId: '1465651642158264047',
 	address: '16313739661670634666L',
+	address_lowercase: '16313739661670634666l',
 	offset: 20,
 	limit: 100,
 };
@@ -133,6 +134,15 @@ describe('Transactions API', () => {
 	describe('GET /api/getTransactionsByAddress', () => {
 		it('using known address should be ok', (done) => {
 			getTransactionsByAddress(params.address, '0', params.limit, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body).to.have.property('transactions').that.is.an('array');
+				checkTransactionsBody(res.body.transactions);
+				done();
+			});
+		});
+
+		it('using known address with lowercase l should be ok', (done) => {
+			getTransactionsByAddress(params.address_lowercase, '0', params.limit, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body).to.have.property('transactions').that.is.an('array');
 				checkTransactionsBody(res.body.transactions);

--- a/utils/core.js
+++ b/utils/core.js
@@ -38,7 +38,12 @@ const get = url => new Promise((resolve, reject) => {
 	});
 });
 
+const parseAddress = function (address) {
+	return address.replace(/ /g, '').replace('l', 'L');
+};
+
 module.exports = {
 	get,
+	parseAddress,
 };
 

--- a/utils/core.js
+++ b/utils/core.js
@@ -39,11 +39,10 @@ const get = url => new Promise((resolve, reject) => {
 });
 
 const parseAddress = function (address) {
-	return address.replace(/ /g, '').replace('l', 'L');
+	return address.replace(/[^0-9lL]/g, '').replace('l', 'L');
 };
 
 module.exports = {
 	get,
 	parseAddress,
 };
-

--- a/utils/core.js
+++ b/utils/core.js
@@ -39,7 +39,7 @@ const get = url => new Promise((resolve, reject) => {
 });
 
 const parseAddress = function (address) {
-	return address.replace(/[^0-9lL]/g, '').replace('l', 'L');
+	return address.replace('l', 'L');
 };
 
 module.exports = {


### PR DESCRIPTION
### What was the problem?
Some inputs are not properly parsed by the frontend client. It results with an empty transaction table on the account page. 

### How did I fix it?
The address input is always parsed against common issues: lowercase `L` and white characters.
This ensures that the core backend always receives an address in the following format: `12345L`.

### How to test it?
Visit the `91540L` page, transactions should be visible.

### Review checklist
- The PR solves #712
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
