### PR TITLE
Increase e2e tests timeout - Closes #460

### DIFF
--- a/features/step_definitions/generic.step.js
+++ b/features/step_definitions/generic.step.js
@@ -37,7 +37,7 @@ const EC = protractor.ExpectedConditions;
 const baseURL = browser.params.baseURL;
 
 defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
-	setDefaultTimeout(20 * 1000);
+	setDefaultTimeout(60 * 1000);
 
 	Given('I\'m on page "{pageAddress}"', (pageAddress, callback) => {
 		browser.ignoreSynchronization = true;


### PR DESCRIPTION
### What was the problem?
Unstable E2E tests on Jenkins

### How did I fix it?
Increased timeout in order to wait more for response before test crash

### How to test it?
`npm run e2e`

### Review checklist
- The PR solves #460 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
