### PR TITLE
Currency picker redesign - Closes #721

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-explorer",
-  "version": "1.6.2-alpha",
+  "version": "1.7.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -44,6 +44,8 @@ import '../components/search';
 import '../components/header';
 import '../components/footer';
 import '../components/currency-selector';
+import '../components/navigation-dropdown';
+import '../components/rounding-selector';
 import '../components/activity-graph';
 import '../components/home';
 import '../components/bread-crumb';
@@ -76,6 +78,8 @@ const App = angular.module('lisk_explorer', [
 	'lisk_explorer.search',
 	'lisk_explorer.tools',
 	'lisk_explorer.currency',
+	'lisk_explorer.navDropdown',
+	'lisk_explorer.roundingMenu',
 	'lisk_explorer.activityGraph',
 	'lisk_explorer.delegateMonitor',
 	'lisk_explorer.home',

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -443,13 +443,14 @@ qrcode + span {
 .currency-code {
 	color: grey;
 	font-family: Menlo, Lucida Sans Typewriter, Courier New, monospace;
-	font-size: 14px;
-	padding-left: 18px;
+  font-size: 14px;
+  padding-left: 18px;
 }
 
-.dropdown .currency-selector li a {
-	display: flex;
-	justify-content: space-between;
+.currency-selector li a {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 @media (max-width: 767px) {

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -444,6 +444,12 @@ qrcode + span {
 	color: grey;
 	font-family: Menlo, Lucida Sans Typewriter, Courier New, monospace;
 	font-size: 14px;
+	padding-left: 18px;
+}
+
+.dropdown .currency-selector li a {
+	display: flex;
+	justify-content: space-between;
 }
 
 @media (max-width: 767px) {

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -440,6 +440,12 @@ qrcode + span {
   border-bottom: 4px solid white;
 }
 
+.currency-code {
+	color: grey;
+	font-family: Menlo, Lucida Sans Typewriter, Courier New, monospace;
+	font-size: 14px;
+}
+
 @media (max-width: 767px) {
   .navbar-nav .caret {
     display: none;

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -376,7 +376,15 @@ qrcode + span {
 .navbar { min-height: 80px; }
 
 .navbar-collapse {
-  overflow: hidden;
+	overflow: hidden;
+}
+
+@media (max-width: 767px) {
+	#header .navbar-collapse.mobile-menu {
+		max-height: 500px;
+		overflow-x: hidden;
+		overflow-y: scroll;
+	}
 }
 
 .navbar-default .navbar-toggle {
@@ -1413,7 +1421,7 @@ table tbody tr:nth-of-type(odd) {
     margin-top: 0;
     display: block;
     background-color: transparent;
-    border: 0;
+		border: 0;
   }
 }
 

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -442,7 +442,7 @@ qrcode + span {
 
 .currency-code {
 	color: grey;
-	font-family: Menlo, Lucida Sans Typewriter, Courier New, monospace;
+	font-family: "Menlo", "Lucida Sans Typewriter", "Courier New", monospace;
   font-size: 14px;
   padding-left: 18px;
 }

--- a/src/components/currency-selector/currency-selector.directive.js
+++ b/src/components/currency-selector/currency-selector.directive.js
@@ -23,7 +23,9 @@ AppCurrency.directive('currencySelector', ($rootScope, $timeout) => {
 		});
 	};
 
-	const CurrencySelectorCtrl = function () {
+	const CurrencySelectorCtrl = function ($scope) {
+		$scope.tickers = {};
+
 		this.setCurrency = (currency) => {
 			$rootScope.currency.symbol = currency;
 			$rootScope.isCollapsed = true;
@@ -32,6 +34,22 @@ AppCurrency.directive('currencySelector', ($rootScope, $timeout) => {
 				localStorage.setItem('lisk_explorer-currency', currency);
 			}
 		};
+
+		$scope.$watch('currency.tickers.LSK',
+			(tickers) => {
+				const getTickers = list => list.filter(code => tickers[code])
+					.map((code) => { // eslint-disable-line arrow-body-style
+						return { code, value: tickers[code] };
+					});
+
+				if (tickers && typeof tickers === 'object') {
+					$scope.tickers = {
+						Popular: getTickers(['BTC', 'USD', 'EUR']),
+						Europe: getTickers(['GBP', 'RUB', 'PLN']),
+						Asia: getTickers(['CNY', 'JPY']),
+					};
+				}
+			});
 	};
 
 	return {

--- a/src/components/currency-selector/currency-selector.html
+++ b/src/components/currency-selector/currency-selector.html
@@ -17,7 +17,8 @@
 -->
 <li class="dropdown" data-uib-dropdown>
 	<a class="dropdown-toggle LSK-menu" id="main-currency-selector" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">
-		{{currency.symbol}} <span class="caret"></span>
+		<span class="visible-xs">Currency&nbsp;<span class="caret"></span></span>
+		<span class="hidden-xs">{{currency.symbol}}&nbsp;<span class="caret"></span></span>
 	</a>
 	<ul class="dropdown-menu currency-selector" role="menu" data-aria-labelledby="main-currency-selector">
 		<li ng-class="key">
@@ -29,7 +30,7 @@
 		</li>
 
 		<span data-ng-repeat-start="(tickerGroup, groupCodes) in tickers"></span>
-		<li data-ng-if="groupCodes.length > 0" role="separator" class="divider" style="clear:both;"></li>
+		<li data-ng-if="groupCodes.length > 0" role="separator" class="divider hidden-xs" style="clear:both;"></li>
 		<li data-ng-if="groupCodes.length > 0" class="dropdown-header" style="clear:both;">{{tickerGroup}}</li>
 
 		<li data-ng-repeat="ticker in groupCodes" ng-class="key">

--- a/src/components/currency-selector/currency-selector.html
+++ b/src/components/currency-selector/currency-selector.html
@@ -23,7 +23,7 @@
 		<li ng-class="key">
 			<a data-ng-click="cs.setCurrency('LSK')"
 			data-ng-class="{active: currency-code.symbol == 'LSK'}" class="LSK">
-				<span>{{'LSK' | currencyCodeToName}}</span>
+				<span class="currency-name">{{'LSK' | currencyCodeToName}}</span>
 				<span class="currency-code">LSK</span>
 			</a>
 		</li>
@@ -35,7 +35,7 @@
 		<li data-ng-repeat="ticker in groupCodes" ng-class="key">
 			<a data-ng-click="cs.setCurrency(ticker.code)"
 			data-ng-class="{active: currency-code.symbol == {{ticker.code}}}" class="{{ticker.code}}">
-				<span>{{ticker.code | currencyCodeToName}}</span>
+				<span class="currency-name">{{ticker.code | currencyCodeToName}}</span>
 				<span class="currency-code">{{ticker.code}}</span>
 			</a>
 		</li>

--- a/src/components/currency-selector/currency-selector.html
+++ b/src/components/currency-selector/currency-selector.html
@@ -19,24 +19,24 @@
 	<a class="dropdown-toggle LSK-menu" id="main-currency-selector" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">
 		{{currency.symbol}} <span class="caret"></span>
 	</a>
-	<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-currency-selector">
+	<ul class="dropdown-menu currency-selector" role="menu" data-aria-labelledby="main-currency-selector">
 		<li ng-class="key">
 			<a data-ng-click="cs.setCurrency('LSK')"
 			data-ng-class="{active: currency-code.symbol == 'LSK'}" class="LSK">
-				{{'LSK' | currencyCodeToName}}
-				<span class="currency-code pull-right">LSK</span>
+				<span>{{'LSK' | currencyCodeToName}}</span>
+				<span class="currency-code">LSK</span>
 			</a>
 		</li>
 
 		<span data-ng-repeat-start="(tickerGroup, groupCodes) in tickers"></span>
-		<li data-ng-if="groupCodes.length > 0" role="separator" class="divider"></li>
-		<li data-ng-if="groupCodes.length > 0" class="dropdown-header">{{tickerGroup}}</li>
+		<li data-ng-if="groupCodes.length > 0" role="separator" class="divider" style="clear:both;"></li>
+		<li data-ng-if="groupCodes.length > 0" class="dropdown-header" style="clear:both;">{{tickerGroup}}</li>
 
 		<li data-ng-repeat="ticker in groupCodes" ng-class="key">
 			<a data-ng-click="cs.setCurrency(ticker.code)"
 			data-ng-class="{active: currency-code.symbol == {{ticker.code}}}" class="{{ticker.code}}">
-				{{ticker.code | currencyCodeToName}}
-				<span class="currency-code pull-right">{{ticker.code}}</span>
+				<span>{{ticker.code | currencyCodeToName}}</span>
+				<span class="currency-code">{{ticker.code}}</span>
 			</a>
 		</li>
 		<span data-ng-repeat-end></span>

--- a/src/components/currency-selector/currency-selector.html
+++ b/src/components/currency-selector/currency-selector.html
@@ -20,11 +20,25 @@
 		{{currency.symbol}} <span class="caret"></span>
 	</a>
 	<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-currency-selector">
-		<li>
-			<a data-ng-click="cs.setCurrency('LSK')" data-ng-class="{active: currency.symbol == 'LSK'}" class="LSK">LSK</a>
+		<li ng-class="key">
+			<a data-ng-click="cs.setCurrency('LSK')"
+			data-ng-class="{active: currency-code.symbol == 'LSK'}" class="LSK">
+				{{'LSK' | currencyCodeToName}}
+				<span class="currency-code pull-right">LSK</span>
+			</a>
 		</li>
-		<li data-ng-if="currency.tickers.LSK" data-ng-repeat="(key, value) in currency.tickers.LSK" ng-class="key">
-			<a data-ng-click="cs.setCurrency(key)" data-ng-class="{active: currency.symbol == {{key}}}" class="{{key}}">{{key}}</a>
+
+		<span data-ng-repeat-start="(tickerGroup, groupCodes) in tickers"></span>
+		<li data-ng-if="groupCodes.length > 0" role="separator" class="divider"></li>
+		<li data-ng-if="groupCodes.length > 0" class="dropdown-header">{{tickerGroup}}</li>
+
+		<li data-ng-repeat="ticker in groupCodes" ng-class="key">
+			<a data-ng-click="cs.setCurrency(ticker.code)"
+			data-ng-class="{active: currency-code.symbol == {{ticker.code}}}" class="{{ticker.code}}">
+				{{ticker.code | currencyCodeToName}}
+				<span class="currency-code pull-right">{{ticker.code}}</span>
+			</a>
 		</li>
+		<span data-ng-repeat-end></span>
 	</ul>
 </li>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -43,26 +43,7 @@
 					<div class="navbar-collapse main-menu" data-ng-class="{collapse: $root.isCollapsed}">
 						<ul class="nav navbar-nav navbar-right">
 							<currency-selector />
-							<li class="dropdown" data-uib-dropdown>
-								<a href id="main-menu-dropdown" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Tools <span class="caret"></span></a>
-								<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-menu-dropdown">
-									<li>
-										<a href="/topAccounts" class="top-accounts">Top Accounts</a>
-									</li>
-									<li>
-										<a href="/activityGraph" class="activity-graph">Activity Graph</a>
-									</li>
-									<li>
-										<a href="/delegateMonitor" class="delegate-monitor">Delegate Monitor</a>
-									</li>
-									<li data-ng-if="$root.marketWatcher">
-										<a href="/marketWatcher" class="market-watcher">Market Watcher</a>
-									</li>
-									<li>
-										<a href="/networkMonitor" class="network-monitor">Network Monitor</a>
-									</li>
-								</ul>
-							</li>
+							<navigation-dropdown />
 						</ul>
 					</div>
 				</span>
@@ -76,27 +57,9 @@
 					<search class="visible-xs mobile-search" mobile-view="true" />
 					<div class="navbar-collapse main-menu mobile-menu" data-ng-class="{collapse: $root.isCollapsed}">
 						<ul class="nav navbar-nav navbar-right">
-							<li class="dropdown" data-uib-dropdown>
-								<a href id="main-menu-dropdown" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Tools <span class="caret"></span></a>
-								<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-menu-dropdown">
-									<li>
-										<a href="/topAccounts" class="top-accounts">Top Accounts</a>
-									</li>
-									<li>
-										<a href="/activityGraph" class="activity-graph">Activity Graph</a>
-									</li>
-									<li>
-										<a href="/delegateMonitor" class="delegate-monitor">Delegate Monitor</a>
-									</li>
-									<li data-ng-if="$root.marketWatcher">
-										<a href="/marketWatcher" class="market-watcher">Market Watcher</a>
-									</li>
-									<li>
-										<a href="/networkMonitor" class="network-monitor">Network Monitor</a>
-									</li>
-								</ul>
-							</li>
+							<navigation-dropdown />
 							<currency-selector />
+							<!-- <rounding-selector /> -->
 						</ul>
 					</div>
 				</span>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -32,15 +32,16 @@
 						<span class="nethash text-center" ng-if="showNethash(blockStatus.nethash | nethash)">{{blockStatus.nethash | nethash}}</span>
 					</a>
 				</div>
-				<button type="button" class="navbar-toggle" data-ng-click="$root.isCollapsed = !$root.isCollapsed">
-					<span class="sr-only">Toggle navigation</span>
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-				</button>
-				<search class="visible-xs mobile-search" mobile-view="true" />
-				<div class="navbar-collapse main-menu" data-ng-class="{collapse: $root.isCollapsed}">
-					<ul class="nav navbar-nav navbar-right">
+				<span class="hidden-xs">
+					<button type="button" class="navbar-toggle" data-ng-click="$root.isCollapsed = !$root.isCollapsed">
+						<span class="sr-only">Toggle navigation</span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+					</button>
+					<search class="visible-xs mobile-search" mobile-view="true" />
+					<div class="navbar-collapse main-menu" data-ng-class="{collapse: $root.isCollapsed}">
+						<ul class="nav navbar-nav navbar-right">
 							<currency-selector />
 							<li class="dropdown" data-uib-dropdown>
 								<a href id="main-menu-dropdown" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Tools <span class="caret"></span></a>
@@ -63,7 +64,42 @@
 								</ul>
 							</li>
 						</ul>
-				</div>
+					</div>
+				</span>
+				<span class="visible-xs">
+					<button type="button" class="navbar-toggle" data-ng-click="$root.isCollapsed = !$root.isCollapsed">
+						<span class="sr-only">Toggle navigation</span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+					</button>
+					<search class="visible-xs mobile-search" mobile-view="true" />
+					<div class="navbar-collapse main-menu mobile-menu" data-ng-class="{collapse: $root.isCollapsed}">
+						<ul class="nav navbar-nav navbar-right">
+							<li class="dropdown" data-uib-dropdown>
+								<a href id="main-menu-dropdown" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Tools <span class="caret"></span></a>
+								<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-menu-dropdown">
+									<li>
+										<a href="/topAccounts" class="top-accounts">Top Accounts</a>
+									</li>
+									<li>
+										<a href="/activityGraph" class="activity-graph">Activity Graph</a>
+									</li>
+									<li>
+										<a href="/delegateMonitor" class="delegate-monitor">Delegate Monitor</a>
+									</li>
+									<li data-ng-if="$root.marketWatcher">
+										<a href="/marketWatcher" class="market-watcher">Market Watcher</a>
+									</li>
+									<li>
+										<a href="/networkMonitor" class="network-monitor">Network Monitor</a>
+									</li>
+								</ul>
+							</li>
+							<currency-selector />
+						</ul>
+					</div>
+				</span>
 				<search class="hidden-xs desktop-search" />
 			</div>
 		</div>

--- a/src/components/navigation-dropdown/index.js
+++ b/src/components/navigation-dropdown/index.js
@@ -1,0 +1,17 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import './navigation-dropdown.module';
+import './navigation-dropdown.directive';

--- a/src/components/navigation-dropdown/navigation-dropdown.directive.js
+++ b/src/components/navigation-dropdown/navigation-dropdown.directive.js
@@ -1,0 +1,34 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import AppNavDropdown from './navigation-dropdown.module';
+import template from './navigation-dropdown.html';
+
+AppNavDropdown.directive('navigationDropdown', ($rootScope, $timeout) => {
+	const CurrencySelectorLink = () => {
+	};
+
+	const CurrencySelectorCtrl = function ($scope) {
+	};
+
+	return {
+		restrict: 'E',
+		replace: true,
+		controller: CurrencySelectorCtrl,
+		controllerAs: 'cs',
+		link: CurrencySelectorLink,
+		template,
+	};
+});

--- a/src/components/navigation-dropdown/navigation-dropdown.directive.js
+++ b/src/components/navigation-dropdown/navigation-dropdown.directive.js
@@ -16,19 +16,11 @@
 import AppNavDropdown from './navigation-dropdown.module';
 import template from './navigation-dropdown.html';
 
-AppNavDropdown.directive('navigationDropdown', ($rootScope, $timeout) => {
-	const CurrencySelectorLink = () => {
-	};
-
-	const CurrencySelectorCtrl = function ($scope) {
-	};
-
+// eslint-disable-next-line arrow-body-style
+AppNavDropdown.directive('navigationDropdown', () => {
 	return {
 		restrict: 'E',
 		replace: true,
-		controller: CurrencySelectorCtrl,
-		controllerAs: 'cs',
-		link: CurrencySelectorLink,
 		template,
 	};
 });

--- a/src/components/navigation-dropdown/navigation-dropdown.html
+++ b/src/components/navigation-dropdown/navigation-dropdown.html
@@ -1,0 +1,37 @@
+<!--
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+-->
+<li class="dropdown" data-uib-dropdown>
+	<a href id="main-menu-dropdown" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Tools <span class="caret"></span></a>
+	<ul class="dropdown-menu" role="menu" data-aria-labelledby="main-menu-dropdown">
+		<li>
+			<a href="/topAccounts" class="top-accounts">Top Accounts</a>
+		</li>
+		<li>
+			<a href="/activityGraph" class="activity-graph">Activity Graph</a>
+		</li>
+		<li>
+			<a href="/delegateMonitor" class="delegate-monitor">Delegate Monitor</a>
+		</li>
+		<li data-ng-if="$root.marketWatcher">
+			<a href="/marketWatcher" class="market-watcher">Market Watcher</a>
+		</li>
+		<li>
+			<a href="/networkMonitor" class="network-monitor">Network Monitor</a>
+		</li>
+	</ul>
+</li>

--- a/src/components/navigation-dropdown/navigation-dropdown.module.js
+++ b/src/components/navigation-dropdown/navigation-dropdown.module.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import angular from 'angular';
+
+const AppNavDropdown = angular.module('lisk_explorer.navDropdown', []);
+
+export default AppNavDropdown;

--- a/src/components/rounding-selector/index.js
+++ b/src/components/rounding-selector/index.js
@@ -1,0 +1,17 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import './rounding-selector.module';
+import './rounding-selector.directive';

--- a/src/components/rounding-selector/rounding-selector.directive.js
+++ b/src/components/rounding-selector/rounding-selector.directive.js
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import AppRounding from './rounding-selector.module';
+import template from './rounding-selector.html';
+
+AppRounding.directive('roundingSelector', ($rootScope, $timeout) => {
+	const RoundingSelectorLink = () => {
+	};
+
+	const RoundingSelectorCtrl = function ($scope) {
+		this.setDecimalPlaces = (setting) => {
+			$rootScope.decimalPlaces = setting;
+			$rootScope.isCollapsed = true;
+		};
+	};
+
+	return {
+		restrict: 'E',
+		replace: true,
+		controller: RoundingSelectorCtrl,
+		controllerAs: 'cs',
+		link: RoundingSelectorLink,
+		template,
+	};
+});

--- a/src/components/rounding-selector/rounding-selector.directive.js
+++ b/src/components/rounding-selector/rounding-selector.directive.js
@@ -16,11 +16,11 @@
 import AppRounding from './rounding-selector.module';
 import template from './rounding-selector.html';
 
-AppRounding.directive('roundingSelector', ($rootScope, $timeout) => {
+AppRounding.directive('roundingSelector', ($rootScope) => {
 	const RoundingSelectorLink = () => {
 	};
 
-	const RoundingSelectorCtrl = function ($scope) {
+	const RoundingSelectorCtrl = function () {
 		this.setDecimalPlaces = (setting) => {
 			$rootScope.decimalPlaces = setting;
 			$rootScope.isCollapsed = true;

--- a/src/components/rounding-selector/rounding-selector.html
+++ b/src/components/rounding-selector/rounding-selector.html
@@ -1,0 +1,34 @@
+<!--
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+-->
+<li class="dropdown">
+	<a href id="main-menu-decimal" class="dropdown-toggle tools-menu" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">Decimal places <span class="caret"></span></a>
+	<ul class="dropdown-menu" role="decimal-menu" data-aria-labelledby="decimal-menu-dropdown">
+		<li data-ng-class='{active: $root.decimalPlaces === undefined}'>
+			<a data-ng-click='cs.setDecimalPlaces(undefined)' class='trim-floating-points'>Trim trailing zeros</a>
+		</li>
+		<li data-ng-class='{active: $root.decimalPlaces === 0}'>
+			<a data-ng-click='cs.setDecimalPlaces(0)' class='round-to-0'>Round to whole number</a>
+		</li>
+		<li data-ng-class='{active: $root.decimalPlaces === 4}'>
+			<a data-ng-click='cs.setDecimalPlaces(4)' class='round-to-4'>Round to 4th decimal place</a>
+		</li>
+		<li data-ng-class='{active: $root.decimalPlaces === 8}'>
+			<a data-ng-click='cs.setDecimalPlaces(8)' class='show-all-8'>Show all decimals</a>
+		</li>
+	</ul>
+</li>

--- a/src/components/rounding-selector/rounding-selector.module.js
+++ b/src/components/rounding-selector/rounding-selector.module.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import angular from 'angular';
+
+const AppRounding = angular.module('lisk_explorer.roundingMenu', []);
+
+export default AppRounding;

--- a/src/filters/currency-code-to-name.js
+++ b/src/filters/currency-code-to-name.js
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-explorer
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import AppFilters from './filters.module';
+
+AppFilters.filter('currencyCodeToName', () => (currencyName) => {
+	const currency = {
+		LSK: 'Lisk',
+
+		// Common
+		USD: 'US Dollar',
+		EUR: 'Euro',
+		BTC: 'Bitcoin',
+
+		// Europe
+		GBP: 'British pound',
+		PLN: 'Polish zloty',
+		RUB: 'Russian ruble',
+
+		// Asia
+		JPY: 'Japanese yen',
+		CNY: 'Chinese yuan',
+	};
+
+	return currency[currencyName] || currencyName;
+});

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -35,3 +35,4 @@ import './tx-sender';
 import './tx-type';
 import './votes';
 import './middle-ellipsis';
+import './currency-code-to-name';


### PR DESCRIPTION
### What was the problem?
The increased number of supported currencies raised a need for making the currency picker more readable.

### How did I fix it?
The currency list was split into three categories: popular/international, European and Asian currencies.

### How to test it?
Run the application, the updated currency picker should be visible.

### Review checklist
- The PR solves #721 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
