### PR TITLE
Display transaction asset data on Transaction page - Closes #747

### DIFF
--- a/src/components/transactions/transactions.html
+++ b/src/components/transactions/transactions.html
@@ -70,9 +70,93 @@
 						</td>
 						<td data-ng-if="!vm.tx.blockId" class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">Unconfirmed</td>
 					</tr>
-					<tr data-ng-if="vm.tx.type == 0 && vm.tx.asset && vm.tx.asset.data">
-						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Memo</strong></td>
-						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.data}}</td>
+				</tbody>
+			</table>
+
+			<h1>{{vm.tx | txType}} details</h1>
+			<table class="table details">
+				<tbody data-ng-if="vm.tx.type == 0">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Data</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.data || '-'}}</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 1">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Public Key</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.signature.publicKey}}</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 2">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Username</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.delegate.username}}</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 4">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Minimum</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.multisignature.min}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Lifetime</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.multisignature.lifetime}} hours</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Keys Group</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">
+							<span data-ng-repeat='key in vm.tx.asset.multisignature.keysgroup'>
+								<span>{{key}}</span>
+							</span>
+						</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 5">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Name</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.name}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Description</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.description || '-'}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Tags</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.tags || '-'}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Type</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.type}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Link</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.link}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Category</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.category}}</td>
+					</tr>
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>Icon</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.dapp.icon || '-'}}</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 6">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>DApp ID</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.inTransfer.dappId}}</td>
+					</tr>
+				</tbody>
+
+				<tbody data-ng-if="vm.tx.type == 7">
+					<tr>
+						<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double"><strong>DApp ID</strong></td>
+						<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">{{vm.tx.asset.outTransfer.dappId}}</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/services/tx-types.js
+++ b/src/services/tx-types.js
@@ -16,12 +16,12 @@
 import AppServices from './services.module';
 
 AppServices.value('txTypes', {
-	0: 'Normal transaction',
+	0: 'Balance transfer',
 	1: 'Second signature creation',
 	2: 'Delegate registration',
 	3: 'Delegate vote',
 	4: 'Multi-signature creation',
-	5: 'Dapp registration',
-	6: 'Dapp deposit',
-	7: 'Dapp withdrawal',
+	5: 'DApp registration',
+	6: 'DApp deposit',
+	7: 'DApp withdrawal',
 });


### PR DESCRIPTION
### What was the problem?
Asset data from transactions not being displayed on Transaction page

### How did I fix it?
New section added on Transaction page

### How to test it?
Connecting to Testnet and accessing the following transactions:
Type 0: `/tx/5072002836908163001`
Type 1: `/tx/3320243316616300582`
Type 2: `/tx/17769273069468847453`
Type 3: `/tx/15602595912374724830`
Type 4: `/tx/8191213966308378713`
Type 5: `/tx/14602496231523117483`
Type 6: `/tx/13847108354832975754` (this is not showing due an core issue https://github.com/LiskHQ/lisk/issues/2194)
Type 7: `/tx/7297225435992500205`

### Review checklist

* The PR solves #747
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
