### PR TITLE
Fix broken links when txs list updates - Closes #763

### DIFF
--- a/src/components/home/home.component.js
+++ b/src/components/home/home.component.js
@@ -18,6 +18,12 @@ import template from './home.html';
 
 const HomeConstructor = function ($scope, $http, $interval) {
 	const vm = this;
+
+	const setHref = (tx) => {
+		tx.hrefSender = tx.senderDelegate ? `/delegate/${tx.senderId}` : `/address/${tx.senderId}`;
+		tx.hrefRecipient = tx.recipientDelegate ? `/delegate/${tx.recipientId}` : `/address/${tx.recipientId}`;
+	};
+
 	vm.getLastBlocks = () => {
 		$http.get('/api/getLastBlocks').then((resp) => {
 			if (resp.data.success) {
@@ -44,9 +50,11 @@ const HomeConstructor = function ($scope, $http, $interval) {
 				if (vm.txs && vm.txs.length > 0) {
 					if (vm.txs[0] !== resp.data.transactions[0]) {
 						vm.txs = resp.data.transactions;
+						vm.txs.map(setHref);
 					}
 				} else {
 					vm.txs = resp.data.transactions;
+					vm.txs.map(setHref);
 				}
 			}
 		});

--- a/src/components/home/home.html
+++ b/src/components/home/home.html
@@ -49,13 +49,13 @@
 							<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double hidden-xs"><a class="ellipsis" href="/tx/{{tx.id}}">{{tx.id}}</a></td>
 							<td class="text-right hidden-xs hidden-sm hidden-md"><span class="ellipsis">{{tx.timestamp | timestamp}}<span></td>
 							<td class="left-padding-xs">
-								<a class="ellipsis" ng-href="{{tx.hrefSender}}">
+								<a class="ellipsis" data-ng-href="{{tx.hrefSender}}">
 									<span class="pull-right hidden-xs">{{tx | txSender}}</span>
 									<span class="pull-left visible-xs">{{tx | txSender | middleEllipsis:10}}</span>
 								</a>
 							</td>
 							<td class="left-padding-xs">
-								<a class="ellipsis" data-ng-show="tx.type == 0" ng-href="{{tx.hrefRecipient}}">
+								<a class="ellipsis" data-ng-show="tx.type == 0" data-ng-href="{{tx.hrefRecipient}}">
 									<span class="pull-right hidden-xs">{{tx | txRecipient}}</span>
 									<span class="pull-left visible-xs">{{tx | txRecipient | middleEllipsis:10}}</span>
 								</a>

--- a/src/components/home/home.html
+++ b/src/components/home/home.html
@@ -49,13 +49,13 @@
 							<td class="left-padding-xs left-padding-s left-padding-m left-padding-l double hidden-xs"><a class="ellipsis" href="/tx/{{tx.id}}">{{tx.id}}</a></td>
 							<td class="text-right hidden-xs hidden-sm hidden-md"><span class="ellipsis">{{tx.timestamp | timestamp}}<span></td>
 							<td class="left-padding-xs">
-								<a class="ellipsis" data-account-href="tx" data-type="sender">
+								<a class="ellipsis" ng-href="{{tx.hrefSender}}">
 									<span class="pull-right hidden-xs">{{tx | txSender}}</span>
 									<span class="pull-left visible-xs">{{tx | txSender | middleEllipsis:10}}</span>
 								</a>
 							</td>
 							<td class="left-padding-xs">
-								<a class="ellipsis" data-ng-show="tx.type == 0" data-account-href="tx" data-type="recipient">
+								<a class="ellipsis" data-ng-show="tx.type == 0" ng-href="{{tx.hrefRecipient}}">
 									<span class="pull-right hidden-xs">{{tx | txRecipient}}</span>
 									<span class="pull-left visible-xs">{{tx | txRecipient | middleEllipsis:10}}</span>
 								</a>


### PR DESCRIPTION
### What was the problem?
Angular directive `accountHref` is not re-triggered when transactions list is updated keeping the Sender/Recipient links the same as the initial loaded.

### How did I fix it?
Setting the `href` attribute when the transactions list is received

### How to test it?
Access the home page and wait for a new transaction to show up.
Sender/Recipient links should navigate to the correct page.

### Review checklist

* The PR solves #763 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
