### PR TITLE
Fix redis warning message - Closes #775

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,19 +126,16 @@ const allowCrossDomain = function (req, res, next) {
 app.use(allowCrossDomain);
 
 app.use((req, res, next) => {
-	if (req.originalUrl.split('/')[1] !== 'api') {
-		return next();
-	}
-
 	logger.info(req.originalUrl);
 
-	if (req.originalUrl === undefined) {
+	if (req.originalUrl === undefined || req.originalUrl.split('/')[1] !== 'api') {
 		return next();
 	}
 
 	if (cache.cacheIgnoreList.indexOf(req.originalUrl) >= 0) {
 		return next();
 	}
+
 	return req.redis.get(req.originalUrl, (err, json) => {
 		if (err) {
 			logger.info(err);
@@ -163,7 +160,7 @@ routes(app);
 logger.info('Routes loaded');
 
 app.use((req, res, next) => {
-	logger.info(req.originalUrl.split('/')[1]);
+	logger.info(req.originalUrl);
 
 	if (req.originalUrl === undefined || req.originalUrl.split('/')[1] !== 'api' || !req.json) {
 		return next();


### PR DESCRIPTION
### What was the problem?
Caching system trying to store empty data on redis

### How did I fix it?
I've added a extra check to cater for this scenario

### How to test it?
Access `/api/invalid/url`
You should see `Cannot GET /api/invalid/url` on the browser
You should NOT see redis warning on server console

### Review checklist

* The PR solves #775 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
