### PR TITLE
Avoid crash when using invalid URI chars - Closes #779

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,13 @@ app.use(allowCrossDomain);
 app.use((req, res, next) => {
 	logger.info(req.originalUrl);
 
+	try {
+		decodeURIComponent(req.path);
+	} catch (err) {
+		logger.info(err);
+		return res.redirect('/');
+	}
+
 	if (req.originalUrl === undefined || req.originalUrl.split('/')[1] !== 'api') {
 		return next();
 	}


### PR DESCRIPTION
### What was the problem?
Server crashing when invalid URI was used

### How did I fix it?
I've added a try/catch to cater for this scenario

### How to test it?
Access `http://localhost:6040/%invalid%url%`
You should be redirected to the home page

### Review checklist

* The PR solves #779 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
