### PR TITLE
Add safety check during Twitter response URL parse

### DIFF
--- a/services/newsfeed/TwitterService.js
+++ b/services/newsfeed/TwitterService.js
@@ -24,13 +24,22 @@ const client = new Twitter({
 	access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
 });
 
+const safeRef = (obj, path) => {
+	try {
+		// eslint-disable-next-line
+		return path.split('.').reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, obj);
+	} catch (e) {
+		return null;
+	}
+};
+
 const tweetUrl = (o) => {
 	if (o.retweeted_status) {
-		return o.retweeted_status.entities.urls[0].url;
+		return safeRef(o, 'retweeted_status.entities.urls.0.url');
 	} else if (o.extended_entities) {
-		return o.extended_entities.media[0].url;
+		return safeRef(o, 'extended_entities.media.0.url');
 	} else if (o.entities) {
-		return o.entities.urls[0].url;
+		return safeRef(o, 'entities.urls.0.url');
 	}
 	return null;
 };


### PR DESCRIPTION
### What was the problem?
The Explorer process crashed when the `/api/newsfeed` was accessed and one of tweets didn't contain an URL.

### How did I fix it?
An additional security check is done before the potential data are accessed.

### How to test it?
Test the `/api/newsfeed` route, the process should not crash.

### Review checklist

* The PR solves #787
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
