### PR TITLE
Use jenkins cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,11 @@ pipeline {
 	stages {
 		stage ('Build dependencies') {
 			steps {
-				sh 'npm install'
+				script {
+					cache_file = restoreCache("package.json")
+					sh 'npm install'
+					saveCache(cache_file, './node_modules', 10)
+				}
 			}
 		}
 		stage ('Run ESLint') {


### PR DESCRIPTION
### What was the problem?
Add cache functions from jenkins library to speed up builds
### How did I fix it?
Adding cache in the `npm install` step
### How to test it?
In Jenkins 
https://jenkins.lisk.io/job/lisk-explorer/job/use_jenkins_cache/