### PR TITLE
Add 'load more' functionality to voters list - Closes #803

### DIFF
--- a/api/accounts.js
+++ b/api/accounts.js
@@ -26,4 +26,22 @@ module.exports = [
 			limit: req.query.limit,
 		}),
 	},
+	{
+		path: 'getVotes',
+		service: 'accounts',
+		params: req => ({
+			publicKey: req.query.publicKey,
+			offset: req.query.offset,
+			limit: req.query.limit,
+		}),
+	},
+	{
+		path: 'getVoters',
+		service: 'accounts',
+		params: req => ({
+			publicKey: req.query.publicKey,
+			offset: req.query.offset,
+			limit: req.query.limit,
+		}),
+	},
 ];

--- a/features/delegate.feature
+++ b/features/delegate.feature
@@ -16,7 +16,7 @@ Feature: Delegate page
   Scenario: should allow to show voters
     Given I'm on page "/delegate/537318935439898807L"
     When I click "show voters button"
-    Then I should see "gottavoteemall • 16313739661670634666L" in "voters" element
+    Then I should see "gottavoteemall • 16313739661670634666L •" in "voters" element
 
   Scenario: should link voters to address page
     Given I'm on page "/delegate/537318935439898807L"

--- a/lib/api/accounts.js
+++ b/lib/api/accounts.js
@@ -309,9 +309,6 @@ module.exports = function (app) {
 				account.getVotes(result, cb);
 			},
 			(result, cb) => {
-				account.getVoters(result, cb);
-			},
-			(result, cb) => {
 				account.getIncomingTxsCnt(result, cb);
 			},
 			(result, cb) => {

--- a/lib/api/accounts.js
+++ b/lib/api/accounts.js
@@ -61,9 +61,9 @@ module.exports = function (app) {
 		this.validPublicKey = publicKey =>
 			(typeof publicKey === 'string' && publicKey.match(/^([A-Fa-f0-9]{2}){32}$/g));
 
-		this.getVotesCall = (account, limit, offset, cb) => {
+		this.getVotesCall = (publicKey, limit, offset, cb) => {
 			request.get({
-				url: `${app.get('lisk address')}/votes?address=${coreUtils.parseAddress(account.address)}&limit=${limit}&offset=${offset}&sort=username:asc`,
+				url: `${app.get('lisk address')}/votes?publicKey=${publicKey}&limit=${limit}&offset=${offset}`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -71,16 +71,16 @@ module.exports = function (app) {
 				}
 
 				if (body && body.data && Array.isArray(body.data.votes)) {
-					return cb(null, body.data.votes);
+					return cb(null, body.data);
 				}
 
 				return cb(null, []);
 			});
 		};
 
-		this.getVotersCall = (account, limit, offset, cb) => {
+		this.getVotersCall = (publicKey, limit, offset, cb) => {
 			request.get({
-				url: `${app.get('lisk address')}/voters?address=${coreUtils.parseAddress(account.address)}&limit=${limit}&offset=${offset}&sort=username:asc`,
+				url: `${app.get('lisk address')}/voters?publicKey=${publicKey}&limit=${limit}&offset=${offset}`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
@@ -88,7 +88,7 @@ module.exports = function (app) {
 				}
 
 				if (body && body.data && Array.isArray(body.data.voters)) {
-					return cb(null, body.data.voters);
+					return cb(null, body.data);
 				}
 				return cb(body.error);
 			});
@@ -179,53 +179,6 @@ module.exports = function (app) {
 			knowledge.setKnowledge(account, () => cb(null, account));
 		};
 
-		this.getVotes = (account, cb) => {
-			if (!account.address) {
-				return cb(null, account);
-			}
-
-			return this.getVotesCall(account, 101, 0, (err, result) => {
-				if (err) {
-					return cb(err || 'Response was unsuccessful');
-				}
-
-				account.votes = result;
-
-				return async.forEach(account.votes, (vote, forEachCallback) => {
-					knowledge.setKnowledge(vote, () => forEachCallback());
-				}, () => cb(null, account));
-			});
-		};
-
-		this.getVoters = (account, cb) => {
-			if (!account.address) {
-				return cb(null, account);
-			}
-
-			const limit = 100;
-			let offset = 0;
-			account.voters = [];
-
-			return async.doUntil(
-				(next) => {
-					this.getVotersCall(account, limit, offset, next);
-				},
-				(data) => {
-					account.voters = _.union(account.voters, data);
-					offset += limit;
-					return data.length < limit;
-				},
-				(err) => {
-					if (err) {
-						return cb(err || 'Response was unsuccessful');
-					}
-
-					return async.forEach(account.voters, (voter, forEachCallback) => {
-						knowledge.setKnowledge(voter, () => forEachCallback());
-					}, () => cb(null, account));
-				});
-		};
-
 		this.getIncomingTxsCnt = (account, cb) => {
 			if (!account.address) {
 				return cb(null, account);
@@ -306,9 +259,6 @@ module.exports = function (app) {
 				account.getForged(result, cb);
 			},
 			(result, cb) => {
-				account.getVotes(result, cb);
-			},
-			(result, cb) => {
 				account.getIncomingTxsCnt(result, cb);
 			},
 			(result, cb) => {
@@ -344,6 +294,64 @@ module.exports = function (app) {
 
 			mappedResult.success = true;
 			return success(mappedResult);
+		});
+	};
+
+	this.getVotes = (params, error, success) => {
+		const account = new Account();
+		const limit = param(params.limit, 101);
+		const offset = param(params.offset, 0);
+
+		if (!params.publicKey) {
+			return error({ success: false, error: 'Missing/Invalid publicKey parameter' });
+		}
+
+		if (params.publicKey && !account.validPublicKey(params.publicKey)) {
+			return error({ success: false, error: 'Invalid publicKey parameter' });
+		}
+
+		return account.getVotesCall(params.publicKey, limit, offset, (err, response) => {
+			if (err) {
+				return error({ success: false, error: (err || 'Response was unsuccessful') });
+			}
+
+			const meta = {
+				limit,
+				offset,
+				count: response.votesUsed,
+			};
+
+			return success({ success: true, meta, votes: response.votes });
+		});
+	};
+
+	this.getVoters = (params, error, success) => {
+		const account = new Account();
+		const limit = param(params.limit, 100);
+		const offset = param(params.offset, 0);
+
+		if (!params.publicKey) {
+			return error({ success: false, error: 'Missing/Invalid publicKey parameter' });
+		}
+
+		if (params.publicKey && !account.validPublicKey(params.publicKey)) {
+			return error({ success: false, error: 'Invalid publicKey parameter' });
+		}
+
+		return account.getVotersCall(params.publicKey, limit, offset, (err, response) => {
+			if (err) {
+				return error({ success: false, error: (err || 'Response was unsuccessful') });
+			}
+
+			const meta = {
+				limit,
+				offset,
+				count: response.votes,
+			};
+
+			return async.forEach(response.voters, (voter, forEachCallback) => {
+				knowledge.setKnowledge(voter, () => forEachCallback());
+			}, () => success({ success: true, meta, voters: response.voters }));
 		});
 	};
 

--- a/src/components/address/address.component.js
+++ b/src/components/address/address.component.js
@@ -27,11 +27,20 @@ const AddressConstructor = function ($rootScope, $stateParams, $location, $http,
 		}).then((resp) => {
 			if (resp.data.success) {
 				vm.address = resp.data;
+				vm.getVotes(vm.address.publicKey);
 			} else {
 				throw new Error('Account was not found!');
 			}
 		}).catch(() => {
 			$location.path('/');
+		});
+	};
+
+	vm.getVotes = (publicKey) => {
+		$http.get('/api/getVotes', { params: { publicKey } }).then((resp) => {
+			if (resp.data.success) {
+				vm.address.votes = resp.data.votes;
+			}
 		});
 	};
 

--- a/src/components/delegate/delegate.component.js
+++ b/src/components/delegate/delegate.component.js
@@ -19,7 +19,9 @@ import template from './delegate.html';
 const DelegateConstructor = function ($rootScope, $stateParams,
 	$location, $http, addressTxs, $state) {
 	const vm = this;
+
 	$rootScope.breadCrumb = { address: $stateParams.delegateId };
+
 	vm.getAddress = () => {
 		$http.get('/api/getAccount', {
 			params: {
@@ -28,8 +30,11 @@ const DelegateConstructor = function ($rootScope, $stateParams,
 		}).then((resp) => {
 			if (resp.data.success) {
 				vm.address = resp.data;
+				vm.getVotes(vm.address.publicKey);
 
-				if (!vm.address.delegate) {
+				if (vm.address.delegate) {
+					vm.getVoters(vm.address.publicKey);
+				} else {
 					$state.go('address', { address: $stateParams.delegateId });
 				}
 			} else {
@@ -37,6 +42,22 @@ const DelegateConstructor = function ($rootScope, $stateParams,
 			}
 		}).catch(() => {
 			$location.path('/');
+		});
+	};
+
+	vm.getVotes = (publicKey) => {
+		$http.get('/api/getVotes', { params: { publicKey } }).then((resp) => {
+			if (resp.data.success) {
+				vm.address.votes = resp.data.votes;
+			}
+		});
+	};
+
+	vm.getVoters = (publicKey) => {
+		$http.get('/api/getVoters', { params: { publicKey } }).then((resp) => {
+			if (resp.data.success) {
+				vm.address.voters = resp.data.voters;
+			}
 		});
 	};
 

--- a/src/components/delegate/delegate.component.js
+++ b/src/components/delegate/delegate.component.js
@@ -57,6 +57,26 @@ const DelegateConstructor = function ($rootScope, $stateParams,
 		$http.get('/api/getVoters', { params: { publicKey } }).then((resp) => {
 			if (resp.data.success) {
 				vm.address.voters = resp.data.voters;
+				vm.address.votersMeta = resp.data.meta;
+				vm.address.votersCount = vm.address.votersMeta.count;
+			}
+		});
+	};
+
+	vm.loadMoreVoters = () => {
+		const limit = vm.address.votersMeta.limit;
+		const offset = vm.address.votersMeta.offset + limit;
+
+		$http.get('/api/getVoters', { params: { publicKey: vm.address.publicKey, limit, offset } }).then((resp) => {
+			if (resp.data.success) {
+				for (let i = 0; i < resp.data.voters.length; i++) {
+					if (vm.address.voters.indexOf(resp.data.voters[i]) < 0) {
+						vm.address.voters.push(resp.data.voters[i]);
+					}
+				}
+
+				vm.address.votersMeta = resp.data.meta;
+				vm.address.votersCount = vm.address.votersMeta.count;
 			}
 		});
 	};

--- a/src/components/delegate/delegate.html
+++ b/src/components/delegate/delegate.html
@@ -71,17 +71,17 @@
 	<div class="delegate-vote" data-ng-if="vm.address.voters">
 		<h1>
 			<a href="" data-ng-show="!showVoters" data-ng-click="showVoters=!showVoters" class="show-voters-button"><small><i class="fa fa-plus-square-o"></i></small></a>
-			<a href="" data-ng-show="showVoters" data-ng-click="showVoters=!showVoters"><small><i class="fa fa-minus-square-o"></i></small></a>            Voters <small>{{vm.address.voters.length}}</small>
+			<a href="" data-ng-show="showVoters" data-ng-click="showVoters=!showVoters"><small><i class="fa fa-minus-square-o"></i></small></a>Voters <small>{{vm.address.votersCount}}</small>
 		</h1>
 		<div class="row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l" data-ng-init="showVoters=false" data-ng-show="showVoters">
 			<div class="col-md-12 voters">
 				<span data-ng-repeat='voter in vm.address.voters'>
-					<span data-ng-if="!$last">
+					<span>
 						<a data-account-href="voter" data-type="voter" class="voter-link">{{voter | votes}}</a>
 						<span class="text-muted">&bull;</span>
 					</span>
-					<span data-ng-if="$last">
-						<a data-account-href="voter" data-type="voter" class="voter-link">{{voter | votes}}</a>
+					<span data-ng-if="$last && vm.address.voters.length < vm.address.votersCount">
+						<span role="button" class="load-more" data-ng-click="vm.loadMoreVoters()"><b>Load more...</b></span>
 					</span>
 				</span>
 			</div>

--- a/test/api/accounts.js
+++ b/test/api/accounts.js
@@ -21,8 +21,8 @@ const params = {
 	address_lowercase: '16313739661670634666l',
 	excessive_offset: '1000000',
 	publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
-	addressWithVotes: '16313739661670634666L',
-	addressWithVoters: '6726252519465624456L',
+	pkWithVotes: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+	pkWithVoters: '904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37',
 };
 
 describe('Accounts API', () => {
@@ -39,6 +39,14 @@ describe('Accounts API', () => {
 		node.get(`/api/getTopAccounts?offset=${id}&limit=${id2}`, done);
 	}
 
+	function getVotes(pk, done) {
+		node.get(`/api/getVotes?publicKey=${pk}`, done);
+	}
+
+	function getVoters(pk, done) {
+		node.get(`/api/getVoters?publicKey=${pk}`, done);
+	}
+
 	function checkAccountTypes(o) {
 		node.expect(o.success).to.be.a('boolean');
 		node.expect(o.multisignatures).to.be.an('array');
@@ -52,8 +60,6 @@ describe('Accounts API', () => {
 		node.expect(o.u_multisignatures).to.be.an('array');
 		node.expect(o.knowledge).to.satisfy(knowledge => !knowledge || typeof knowledge === 'object');
 		node.expect(o.delegate).to.satisfy(delegate => delegate === null || typeof delegate === 'object');
-		node.expect(o.votes).to.satisfy(votes => votes === null || typeof votes === 'object');
-		node.expect(o.voters).to.satisfy(voters => voters === null || typeof voters === 'object');
 		node.expect(o.incoming_cnt).to.be.a('string');
 		node.expect(o.outgoing_cnt).to.be.a('string');
 	}
@@ -72,8 +78,6 @@ describe('Accounts API', () => {
 			'u_multisignatures',
 			'knowledge',
 			'delegate',
-			'votes',
-			'voters',
 			'incoming_cnt',
 			'outgoing_cnt');
 
@@ -138,24 +142,6 @@ describe('Accounts API', () => {
 			getAccount(params.address, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
 				checkAccount(res.body);
-				done();
-			});
-		});
-
-		it('using delegate with 2 voters should return 2 voters', (done) => {
-			getAccount(params.address_delegate, (err, res) => {
-				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
-				node.expect(res.body.voters.length).to.be.equal(2);
-				done();
-			});
-		});
-
-		it('using address with 101 votes should return all 101 votes', (done) => {
-			getAccount(params.address, (err, res) => {
-				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
-				node.expect(res.body.votes.length).to.be.equal(101);
 				done();
 			});
 		});
@@ -233,38 +219,20 @@ describe('Accounts API', () => {
 			});
 		});
 
-		it('the response should have votes', (done) => {
-			getAccount(params.addressWithVotes, (err, res) => {
+		it('using address with 101 votes should return all 101 votes', (done) => {
+			getVotes(params.pkWithVotes, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
 				node.expect(res.body.votes).to.have.lengthOf(101);
-				const checkVotes = (o) => {
-					node.expect(o).to.have.all.keys(
-						'address',
-						'balance',
-						'knowledge',
-						'publicKey',
-						'username');
-					node.expect(o.knowledge).to.be.an('object');
-				};
-				res.body.votes.map(checkVotes);
+				node.expect(res.body).to.have.all.keys('success', 'meta', 'votes');
 				done();
 			});
 		});
 
-		it('the response should have voters', (done) => {
-			getAccount(params.addressWithVoters, (err, res) => {
+		it('using delegate with 2 voters should return 2 voters', (done) => {
+			getVoters(params.pkWithVoters, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.not.be.equal(undefined);
-				checkAccount(res.body);
 				node.expect(res.body.voters).to.have.lengthOf(2);
-				const checkVoters = (o) => {
-					node.expect(o).to.have.all.keys(
-						'address',
-						'balance',
-						'knowledge',
-						'publicKey');
-				};
-				res.body.voters.map(checkVoters);
+				node.expect(res.body).to.have.all.keys('success', 'meta', 'voters');
 				done();
 			});
 		});


### PR DESCRIPTION
### What was the problem?
Address page takes ages to load when the address is a delegate and have too many voters

### How did I fix it?
The `Load more...` functionality was added to the voters list

### How to test it?
Access `/address/17621212458226596154L` connected to a mainnet node.

### Review checklist

* The PR solves #803 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
