### PR TITLE
Content security policy issue - Closes #808

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ app.use((req, res, next) => {
 	res.setHeader('Content-Security-Policy',
 		[`frame-ancestors 'none'; default-src 'self';`,
 		`connect-src 'self' ${wsSrc};`,
-		`img-src 'self' https://*.tile.openstreetmap.org www.google-analytics.com stats.g.doubleclick.net;`,
+		`img-src 'self' https:;`,
 		`style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;`,
 		`script-src 'self' 'sha256-L6JyfNh6FtKC6umsFxtawnD4dtWi8szFRQZU0tVgsQk=' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com;`,
 		`font-src 'self' https://fonts.gstatic.com`].join(' '));

--- a/app.js
+++ b/app.js
@@ -64,17 +64,21 @@ app.use((req, res, next) => {
 	res.setHeader('X-Frame-Options', 'DENY');
 	res.setHeader('X-Content-Type-Options', 'nosniff');
 	res.setHeader('X-XSS-Protection', '1; mode=block');
-	const wsSrc = `ws://${req.get('host')} wss://${req.get('host')}`;
 
 	/* eslint-disable */
-	res.setHeader('Content-Security-Policy',
-		[`frame-ancestors 'none'; default-src 'self';`,
-		`connect-src 'self' ${wsSrc};`,
+	const connectSrc = `ws://${req.get('host')} wss://${req.get('host')}`;
+	const contentSecurityPolicy = [
+		`default-src 'self';`,
+		`frame-ancestors 'none';`,
+		`connect-src 'self' ${connectSrc};`,
 		`img-src 'self' https:;`,
 		`style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;`,
 		`script-src 'self' 'sha256-L6JyfNh6FtKC6umsFxtawnD4dtWi8szFRQZU0tVgsQk=' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com;`,
-		`font-src 'self' https://fonts.gstatic.com`].join(' '));
+		`font-src 'self' https://fonts.gstatic.com`,
+	].join(' ');
 	/* eslint-enable */
+
+	res.setHeader('Content-Security-Policy', contentSecurityPolicy);
 	return next();
 });
 

--- a/app.js
+++ b/app.js
@@ -65,13 +65,14 @@ app.use((req, res, next) => {
 	res.setHeader('X-Content-Type-Options', 'nosniff');
 	res.setHeader('X-XSS-Protection', '1; mode=block');
 	const wsSrc = `ws://${req.get('host')} wss://${req.get('host')}`;
+
 	/* eslint-disable */
 	res.setHeader('Content-Security-Policy',
 		[`frame-ancestors 'none'; default-src 'self';`,
 		`connect-src 'self' ${wsSrc};`,
 		`img-src 'self' https://*.tile.openstreetmap.org www.google-analytics.com stats.g.doubleclick.net;`,
 		`style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;`,
-		`script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com;`,
+		`script-src 'self' 'sha256-L6JyfNh6FtKC6umsFxtawnD4dtWi8szFRQZU0tVgsQk=' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com;`,
 		`font-src 'self' https://fonts.gstatic.com`].join(' '));
 	/* eslint-enable */
 	return next();


### PR DESCRIPTION
### What was the problem?
After implementation of `Google Tag Manager` the console intermittently shows a `img-src` CSP violation. It happens because GTM loads some assets onto the page to keep track of it and for some reason the source of these assets can change based on the location where the page is accessed.

### How did I fix it?
As the list of possibles domains for google is very long (google.com, google.de, google.co.uk, etc..) to be whitelisted, I've expanded the `img-src` policy to any secure source (**https**).
In addition, I've restricted the `script-src` by removing the `unsafe-inline` and adding the inline script hash instead.

### How to test it?
Load the page and check the console.

### Review checklist

* The PR solves #808 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
