### PR TITLE
Allow searching for one digit address - Closes #687

### DIFF
--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -18,7 +18,7 @@ module.exports = function (app, api) {
 	this.version = () => ({ version: app.get('version') });
 
 	const exchange = app.exchange;
-	const addressReg = /^[0-9]{2,21}[L|l]$/;
+	const addressReg = /^[0-9]{1,21}[L|l]$/;
 	const publicKeyReg = /^[0-9a-f]{64}$/;
 	const usernameReg = /[a-z!@$&_.]/;
 


### PR DESCRIPTION
### What was the problem?
Search bar not returning one digit address

### How did I fix it?
Updated the regular expression that validates addresses

### How to test it?
Search for `0L`

### Review checklist

* The PR solves #687 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
