### PR TITLE
 Configure cookie expiry date - Closes #841

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -26,7 +26,6 @@ import 'angular-cookies';
 // styles
 import 'amstock3/amcharts/style.css';
 import 'bootstrap/dist/css/bootstrap.css';
-import 'font-awesome/css/font-awesome.css';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import 'angular-advanced-searchbox/dist/angular-advanced-searchbox.min.css';

--- a/src/components/cookies-banner/cookies-banner.directive.js
+++ b/src/components/cookies-banner/cookies-banner.directive.js
@@ -20,7 +20,7 @@ const directiveCtrl = ($scope, $cookies) => {
 	$scope.visible = true;
 	const cookieKey = 'cookiesBannerConfirmed';
 
-	// setting expireDate to 2 years ahead
+	// setting the expiredate to 2years ahead
 	const expireDate = new Date();
 	expireDate.setDate(expireDate.getDate() + 730);
 

--- a/src/components/cookies-banner/cookies-banner.directive.js
+++ b/src/components/cookies-banner/cookies-banner.directive.js
@@ -22,11 +22,12 @@ const directiveCtrl = ($scope, $cookies) => {
 
 	// setting the expiredate to 2years ahead
 	const expireDate = new Date();
-	expireDate.setDate(expireDate.getDate() + 730);
+	const expireDays = 365 * 2;
+	expireDate.setDate(expireDate.getDate() + expireDays);
 
 	$scope.clicked = () => {
 		$scope.visible = false;
-		$cookies.put(cookieKey, 'true', { 'expires': expireDate });
+		$cookies.put(cookieKey, 'true', { expires: expireDate });
 	};
 
 	const result = $cookies.get(cookieKey);

--- a/src/components/cookies-banner/cookies-banner.directive.js
+++ b/src/components/cookies-banner/cookies-banner.directive.js
@@ -20,9 +20,13 @@ const directiveCtrl = ($scope, $cookies) => {
 	$scope.visible = true;
 	const cookieKey = 'cookiesBannerConfirmed';
 
+	// setting expireDate to 2 years ahead
+	const expireDate = new Date();
+	expireDate.setDate(expireDate.getDate() + 730);
+
 	$scope.clicked = () => {
 		$scope.visible = false;
-		$cookies.put(cookieKey, 'true');
+		$cookies.put(cookieKey, 'true', { 'expires': expireDate });
 	};
 
 	const result = $cookies.get(cookieKey);


### PR DESCRIPTION
### What was the problem?
Cookie expire date for the cookie banner was not working.

### How did I fix it?
- set expireDate to 2 years ahead on cookie-banner.directive.js

### How to test it?
- you can test it on console by removing the cookie and recreate the cookie

### Review checklist

* The PR solves #841 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
