### PR TITLE
Adjust Spacing on big-info element -  Closes #852 

### DIFF
--- a/known.json
+++ b/known.json
@@ -1,26 +1,4 @@
 {
     "address"               : { "owner" : "owner", "description" : "description" },
-	"6566229458323231555L"	: { "owner": "Genesis Account", "description": "" },
-	"9569486828221897676L"	: { "owner": "ARK", "description": "Token Exchange Campaign" },
-	"18278674964748191682L"	: { "owner": "Poloniex", "description": "Hot Wallet" },
-	"2226471703256329822L"	: { "owner": "Poloniex", "description": "Cold Wallet" },
-	"11917631413532719541L"	: { "owner": "Oliver", "description": "LiskHQ" },
-	"8201357239823655010L"	: { "owner": "Max", "description": "LiskHQ" },
-	"6687808873757044786L"	: { "owner": "Bittrex", "description": "Main Wallet" },
-	"13724180208900114961L"	: { "owner": "Yobit", "description": "Main Wallet" },
-	"13892601275403076526L"	: { "owner": "Bitbay.net", "description": "Main Wallet" },
-	"15434119221255134066L"	: { "owner": "Bounty Assets", "description": "LiskHQ" },
-	"14175575863689886451L"	: { "owner": "Adviser Assets", "description": "LiskHQ" },
-	"5726759782318848681L"	: { "owner": "Lisk Foundation", "description": "LiskHQ" },
-	"15841793714384967784L"	: { "owner": "Lisk Community Assets", "description": "LiskHQ" },
-	"3040783849904107057L"	: { "owner": "Coincheck.com", "description": "Old Wallet" },
-	"6300322192409448238L"	: { "owner": "Iconomi ICO", "description": "Main Wallet"},
-	"11737606468871099380L" : { "owner" : "Changelly", "description" : "Main Wallet" },
-  	"15441526754256992144L" : { "owner" : "HitBTC.com", "description" : "Hot Wallet" },
-	"2797034409072178585L" 	: { "owner" : "BitBay.net", "description" : "Withdrawal Wallet" },
-	"15610359283786884938L" : { "owner" : "Binance", "description" : "Hot Wallet" },
-	"14367838290034827614L" : { "owner" : "Coincheck.com", "description" : "Old Wallet" },
-	"16293716040102736949L" : { "owner" : "Coincheck.com", "description" : "Main Wallet"},
-	"9094944264474023843L"  : { "owner" : "ICONOMI", "description" : "ICO Wallet"},
-	"12167418142926850031L" : { "owner" : "Binance", "description" : "Main Wallet"}
+    "18234943547133247982L" : { "owner" : "Explorer Account", "description" : "Known addresses test" }
 }

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -1194,7 +1194,7 @@ a.v_highlight_more {
 }
 
 .big-info {
-  padding-bottom: 0px;
+  padding-bottom: 24px;
   padding-top: 0px;
 }
 
@@ -1215,10 +1215,18 @@ a.v_highlight_more {
   line-height: 32px;
 }
 
+.top-pb {
+  padding-bottom: 0px;
+}
+
 @media (max-width: 768px) {
   .big-info {
-    padding-bottom: 0px;
+    padding-bottom: 12px;
     padding-top: 0px;
+  }
+
+  .top-pb {
+    padding-bottom: 0px;
   }
 }
 

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -1198,7 +1198,7 @@ a.v_highlight_more {
 }
 
 .big-info {
-  padding-bottom: 24px;
+  padding-bottom: 0px;
   padding-top: 0px;
 }
 
@@ -1221,7 +1221,7 @@ a.v_highlight_more {
 
 @media (max-width: 768px) {
   .big-info {
-    padding-bottom: 12px;
+    padding-bottom: 0px;
     padding-top: 0px;
   }
 }

--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -958,7 +958,6 @@ qrcode + span {
     white-space:normal;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    width: 100%;
 }
 
 .pk-mobile-style {
@@ -1137,9 +1136,6 @@ qrcode + span {
   -webkit-animation-duration: 2s;
   -webkit-animation-iteration-count: infinite;
   -webkit-animation-timing-function: linear;
-}
-
-.transaction-vin-vout {
 }
 
 .v_highlight {

--- a/src/components/footer/footer.html
+++ b/src/components/footer/footer.html
@@ -29,16 +29,16 @@
 				</a>
 			</div>
 			<div class="col-right col-sm-10 social-networks">
-				<a href="https://gitter.im/LiskHQ/lisk" target="_blank" title="Gitter" class="link gitter-link hidden-xs"><i class="fa fa-gitter fa-2x"></i></a>
+				<a href="https://gitter.im/LiskHQ/lisk" target="_blank" title="Gitter" class="link gitter-link hidden-xs"><i class="fab fa-gitter fa-2x"></i></a>
 				<a href="https://github.com/LiskHQ" target="_blank" title="Github" class="link github-link hidden-xs"><i class="fa fa-github fa-2x"></i></a>
 				<a href="https://twitter.com/LiskHQ" target="_blank" title="Twitter" class="link twitter-link hidden-xs"><i class="fa fa-twitter fa-2x"></i></a>
 				<a href="https://www.facebook.com/LiskHQ" target="_blank" title="Facebook" class="link facebook-link"><i class="fa fa-facebook fa-2x"></i></a>
-        <a href="https://blog.lisk.io" target="_blank" title="Lisk Blog" class="link blog-link"><i class="fab fa-medium fa-2x"></i></a>
-				<a href="https://www.reddit.com/r/Lisk/" target="_blank" title="Reddit" class="link reddit-link hidden-xs"><i class="fa fa-reddit-square fa-2x"></i></a>
+ 				<a href="https://blog.lisk.io" target="_blank" title="Lisk Blog" class="link blog-link"><i class="fab fa-medium-m fa-2x"></i></a>
+				<a href="https://www.reddit.com/r/Lisk/" target="_blank" title="Reddit" class="link reddit-link hidden-xs"><i class="fab fa-reddit-alien fa-2x"></i></a>
 				<a href="https://www.instagram.com/liskhq/" target="_blank" title="Instagram" class="link instagram-link hidden-xs"><i class="fa fa-instagram fa-2x"></i></a>
 				<a href="https://www.youtube.com/channel/UCuqpGfg_bOQ8Ja4pj811PWg/featured" target="_blank" title="YouTube hidden-xs" class="link youtube-link"><i class="fa fa-youtube fa-2x"></i></a>
-				<a href="https://lisk.chat" target="_blank" title="Lisk Chat" class="link chat-link hidden-xs">Chat/Gitter</i></a>
-				<a href="https://t.me/Lisk_HQ" target="_blank" title="Lisk HQ" class="link telegram-link hidden-xs"><i class="fa fa-telegram fa-2x"></i></a>
+				<a href="https://lisk.chat" target="_blank" title="Lisk Chat" class="link chat-link hidden-xs"><i class="fab fa-rocketchat fa-2x"></i></a>
+				<a href="https://t.me/Lisk_HQ" target="_blank" title="Lisk HQ" class="link telegram-link hidden-xs"><i class="fab fa-telegram-plane fa-2x"></i></a>
 				<a href="https://www.linkedin.com/company/lisk/" target="_blank" title="LinkedIn" class="link linkedin-link hidden-xs"><i class="fa fa-linkedin fa-2x"></i></a>
 			</div>
 		</div>

--- a/src/components/home/home.html
+++ b/src/components/home/home.html
@@ -27,7 +27,7 @@
 		<div class="col-xs-12 col-md-6">
 			<div class="row">
 				<div class="col-xs-6 col-sm-5">
-					<div class="row big-info">
+					<div class="row big-info top-pb">
 						<div class="col-xs-12">
 							<div class="pull-left delegates">
 								<p class="small-title">Delegates</p>
@@ -41,7 +41,7 @@
 					</div>
 				</div>
 				<div class="col-xs-6 col-sm-5">
-					<div class="row big-info">
+					<div class="row big-info top-pb">
 						<div class="col-xs-12">
 							<div class="pull-left last-block">
 								<p class="small-title">Last Block By</p>
@@ -63,7 +63,7 @@
 				</div>
 
 				<div class="col-xs-6 col-sm-5">
-					<div class="row big-info">
+					<div class="row big-info top-pb">
 						<div class="col-xs-12">
 							<div class="pull-left active-nodes">
 								<p class="small-title">Connected Peers</p>
@@ -79,7 +79,7 @@
 				</div>
 
 				<div class="col-xs-6 col-sm-5">
-					<div class="row big-info">
+					<div class="row big-info top-pb">
 						<div class="col-xs-12">
 							<div class="pull-left volume">
 								<p class="small-title">Volume <span class="text-muted">({{$root.currency.symbol}})</span></p>
@@ -102,7 +102,7 @@
 			</div>
 		</div>
 		<div class="col-xs-12 col-md-6">
-			<div class="big-info">
+			<div class="big-info top-pb">
 				<p class="small-title">Latest blocks<a href="/blocks/" class="pull-right">More<span class="hidden-xs"> blocks</span><span class="glyphicon glyphicon-chevron-right"></span></a></p>
 			</div>
 
@@ -145,7 +145,7 @@
 
 	<div class="row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
 		<div class="col-xs-12">
-			<div class="big-info">
+			<div class="big-info top-pb">
 				<p class="small-title">Latest transactions<a href="/txs/" class="pull-right">More<span class="hidden-xs"> transactions</span><span class="glyphicon glyphicon-chevron-right"></span></a></p>
 			</div>
 			<!-- <h2 class="left-padding-m left-padding-l">Latest transactions</h2> -->


### PR DESCRIPTION
### What was the problem?
The current spacings do not look well on the desktop view.
At the landing page, the padding-bottom for the .big-info element is not needed there and should be reduced to 0.

### How did I fix it?
Added a new class 'top-pb' to the elements that has .big-info at the landing page, and set the value of the padding-bottom 0px.

### How to test it?
checked on the browser.

### Review checklist

* The PR solves #852 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
