### PR TITLE
Currency picker fix - #849

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -1600,3 +1600,9 @@ table tbody tr:nth-of-type(odd) {
     padding-left: 32px;
   }
 }
+
+li.dropdown.disabled a {
+	color: grey;
+}
+
+

--- a/src/components/bread-crumb/bread-crumb.html
+++ b/src/components/bread-crumb/bread-crumb.html
@@ -16,7 +16,7 @@
  */
 -->
 <div class="row breadcrumb-row">
-	<div class="col-sm-8">
+	<div class="col-sm-7">
 		<ol class="breadcrumb">
 			<li data-ng-repeat="section in sections">
 				<a class="text-capitalize" data-ng-if="section.url != '#'" href="{{section.url}}">{{section.name | alterWordSeparation: 'spaceSeparated'}}</a>
@@ -24,7 +24,7 @@
 			</li>
 		</ol>
 	</div>
-	<div class="col-sm-4 breadcrumb breadcrumb-currency-picker pull-right">
+	<div class="col-sm-5 breadcrumb breadcrumb-currency-picker pull-right">
 		<ul class="hidden-xs"><currency-selector /></ul>
 		<ul class="hidden-xs"><rounding-selector /></ul>
 	</div>

--- a/src/components/currency-selector/currency-selector.html
+++ b/src/components/currency-selector/currency-selector.html
@@ -18,7 +18,7 @@
 <li class="dropdown" data-uib-dropdown>
 	<a class="dropdown-toggle LSK-menu" id="main-currency-selector" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">
 		<span class="visible-xs">Currency&nbsp;<span class="caret"></span></span>
-		<span class="hidden-xs">{{currency.symbol}}&nbsp;<span class="caret"></span></span>
+		<span class="hidden-xs"><strong>{{currency.symbol}}</strong>&nbsp;<span class="caret"></span></span>
 	</a>
 	<ul class="dropdown-menu dropdown-menu-right currency-selector" role="menu" data-aria-labelledby="main-currency-selector">
 		<li ng-class="key">

--- a/src/components/rounding-selector/rounding-selector.directive.js
+++ b/src/components/rounding-selector/rounding-selector.directive.js
@@ -31,7 +31,7 @@ AppRounding.directive('roundingSelector', ($rootScope) => {
 		restrict: 'E',
 		replace: true,
 		controller: RoundingSelectorCtrl,
-		controllerAs: 'cs',
+		controllerAs: 'rs',
 		link: RoundingSelectorLink,
 		template,
 	};

--- a/src/components/rounding-selector/rounding-selector.html
+++ b/src/components/rounding-selector/rounding-selector.html
@@ -22,16 +22,16 @@
 	</a>
 	<ul class="dropdown-menu dropdown-menu-right" role="decimal-menu" data-aria-labelledby="decimal-menu-dropdown">
 		<li data-ng-class='{active: $root.decimalPlaces === undefined}'>
-			<a data-ng-click='cs.setDecimalPlaces(undefined)' class='trim-floating-points'>Trim trailing zeros</a>
+			<a data-ng-click='rs.setDecimalPlaces(undefined)' class='trim-floating-points'>Trim trailing zeros</a>
 		</li>
 		<li data-ng-class='{active: $root.decimalPlaces === 0}'>
-			<a data-ng-click='cs.setDecimalPlaces(0)' class='round-to-0'>Round to whole number</a>
+			<a data-ng-click='rs.setDecimalPlaces(0)' class='round-to-0'>Round to whole number</a>
 		</li>
 		<li data-ng-class='{active: $root.decimalPlaces === 4}'>
-			<a data-ng-click='cs.setDecimalPlaces(4)' class='round-to-4'>Round to 4th decimal place</a>
+			<a data-ng-click='rs.setDecimalPlaces(4)' class='round-to-4'>Round to 4th decimal place</a>
 		</li>
 		<li data-ng-class='{active: $root.decimalPlaces === 8}'>
-			<a data-ng-click='cs.setDecimalPlaces(8)' class='show-all-8'>Show all decimals</a>
+			<a data-ng-click='rs.setDecimalPlaces(8)' class='show-all-8'>Show all decimals</a>
 		</li>
 	</ul>
 </li>

--- a/src/components/rounding-selector/rounding-selector.html
+++ b/src/components/rounding-selector/rounding-selector.html
@@ -15,10 +15,10 @@
  *
  */
 -->
-<li class="dropdown" data-uib-dropdown>
+<li class="dropdown" data-uib-dropdown data-ng-class="{'disabled': ($root.currency.symbol !== 'BTC' && $root.currency.symbol !== 'LSK')}">
 	<a class="dropdown-toggle rounding-menu" id="main-rounding-selector" data-uib-dropdown-toggle data-aria-haspopup="true" role="button" data-aria-expanded="false">
-		<span class="visible-xs">Decimal&nbsp;<span class="caret"></span></span>
-		<span class="hidden-xs">Decimal&nbsp;places&nbsp;<span class="caret"></span></span>
+		<span class="visible-xs">Decimal&nbsp;places<span class="caret"></span></span>
+		<span class="hidden-xs">Decimal&nbsp;places:&nbsp;<strong>{{$root.decimalPlaces !== undefined ? $root.decimalPlaces : 'd'}}</strong>&nbsp;<span class="caret"></span></span>
 	</a>
 	<ul class="dropdown-menu dropdown-menu-right" role="decimal-menu" data-aria-labelledby="decimal-menu-dropdown">
 		<li data-ng-class='{active: $root.decimalPlaces === undefined}'>


### PR DESCRIPTION
### What was the problem?
The currency selector didn't work due to the namespace collision.

### How did I fix it?
Two different namespaces are used for the currency selector (`cs`) and for the rounding selector (`rs`). There are also few UI fixes included.
 
### How to test it?
Decimal places and currency should be able to set.

### Review checklist

* The PR solves #849
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
