### PR TITLE
Adjust Spacing on big-info elements 2 - Closes #852 

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -958,7 +958,6 @@ qrcode + span {
     white-space:normal;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    width: 100%;
 }
 
 .pk-mobile-style {
@@ -1139,8 +1138,6 @@ qrcode + span {
   -webkit-animation-timing-function: linear;
 }
 
-.transaction-vin-vout {
-}
 
 .v_highlight {
   margin-bottom: 1em;
@@ -1197,8 +1194,8 @@ a.v_highlight_more {
   display: none;
 }
 
-.big-info {
-  padding-bottom: 24px;
+.top-pb .big-info {
+  padding-bottom: 0px;
   padding-top: 0px;
 }
 
@@ -1220,8 +1217,8 @@ a.v_highlight_more {
 }
 
 @media (max-width: 768px) {
-  .big-info {
-    padding-bottom: 12px;
+  .top-pb .big-info {
+    padding-bottom: 0px;
     padding-top: 0px;
   }
 }

--- a/src/components/home/home.html
+++ b/src/components/home/home.html
@@ -22,7 +22,7 @@
 	<h1>
 		Lisk Blockchain Explorer
 	</h1>
-
+<div class="top-pb">
 	<div class="row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
 		<div class="col-xs-12 col-md-6">
 			<div class="row">
@@ -203,4 +203,5 @@
 			</div>
 		</div>
 	</div>
+</div>
 </section>

--- a/src/components/home/home.html
+++ b/src/components/home/home.html
@@ -22,8 +22,7 @@
 	<h1>
 		Lisk Blockchain Explorer
 	</h1>
-<div class="top-pb">
-	<div class="row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
+	<div class="top-pb row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
 		<div class="col-xs-12 col-md-6">
 			<div class="row">
 				<div class="col-xs-6 col-sm-5">
@@ -143,7 +142,7 @@
 		</div>
 	</div>
 
-	<div class="row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
+	<div class="top-pb row horizontal-padding-xs horizontal-padding-s horizontal-padding-m horizontal-padding-l">
 		<div class="col-xs-12">
 			<div class="big-info">
 				<p class="small-title">Latest transactions<a href="/txs/" class="pull-right">More<span class="hidden-xs"> transactions</span><span class="glyphicon glyphicon-chevron-right"></span></a></p>
@@ -203,5 +202,4 @@
 			</div>
 		</div>
 	</div>
-</div>
 </section>


### PR DESCRIPTION
### What was the problem?

The current spacings do not look well on the desktop view.
At the landing page, the padding-bottom for the .big-info element is not needed there and should be reduced to 0.

### How did I fix it?

Added a new class .top-pb at parent divs of .big-info on home.html, and set the value of padding-bottom 0px.

### How to test it?

Checked on the browser.

### Review checklist

* The PR solves #852 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
