### PR TITLE
Align logo and nav bar to the container - Closes #859

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -408,10 +408,7 @@ qrcode + span {
   color: white;
   font-family: 'Roboto', 'Ubuntu', sans-serif;
   margin-left: 1px;
-  padding-left: 25px;
-  padding-right: 25px;
-  padding-top: 30px;
-  padding-bottom: 30px;
+  padding: 30px 0px 30px 50px;
 }
 
 .navbar-default .navbar-nav>.active>a, .navbar-default .navbar-nav>.active>a:focus {

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -35,7 +35,7 @@
   color: white;
   height: 80px;
   line-height: 44px;
-  padding: 18px 5px 18px 8px;
+  padding: 18px 5px 18px 0px;
   text-align: left;
 }
 


### PR DESCRIPTION
### What was the problem?
The logo and the pull-down menu at right were not aligned to the container below.

### How did I fix it?
Changed the paddings.

### How to test it?
Checked on the browser.

### Review checklist

* The PR solves #859 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
