### PR TITLE
Add a page indicator to account page - Closes #858

### DIFF
--- a/src/assets/styles/common.css
+++ b/src/assets/styles/common.css
@@ -625,6 +625,10 @@ a.btn-pagination-inactive {
   border-style: none;
 }
 
+.address-currpage {
+  font-size: 1.1em;
+  font-weight: bold;
+}
 
 .col-gray {
   -moz-border-radius: 5px;

--- a/src/components/blocks/blocks.html
+++ b/src/components/blocks/blocks.html
@@ -75,7 +75,7 @@
                         <a href="blocks/{{page}}" data-ng-class="{{page}} === {{vm.pagination.currentPage}} ? 'curr-page' : 'tx-other'">{{ page }}</a>
                     </li>
                     <li>
-                        <a data-ng-class="{'disabled': !(vm.pagination.more && vm.pagination.nextPage != 0), 'btn-pagination': vm.pagination.more}" data-ng-disabled="!(vm.pagination.more && vm.pagination.nextPage != 0)" href="/blocks/{{vm.pagination.nextPage}}">
+                        <a data-ng-class="{'btn-pagination-inactive': !(vm.pagination.more && vm.pagination.nextPage != 0), 'btn-pagination': vm.pagination.more}" data-ng-disabled="!(vm.pagination.more && vm.pagination.nextPage != 0)" href="/blocks/{{vm.pagination.nextPage}}">
                             <i class="fas fa-caret-right fa-lg"></i>
                         </a>
                     </li>

--- a/src/services/pagination.js
+++ b/src/services/pagination.js
@@ -101,7 +101,7 @@ Pagination.prototype.loadPrev = function () {
 
 Pagination.prototype.loadPageOffset = function (offset) {
 	if (offset > 0) this.nextOffset(offset);
-	if (offset < 0) this.prevOffset(offset);
+	if (offset < 0) this.prevOffset(-offset);
 	this.loadData();
 };
 

--- a/src/shared/transactions-list/transactions-list.html
+++ b/src/shared/transactions-list/transactions-list.html
@@ -50,11 +50,17 @@
 	</table>
 	<nav>
 		<ul class="nav-pagination">
-			<li data-ng-disabled="!txs.hasPrev">
+			<li data-ng-if="!txs.currentPage" data-ng-disabled="!txs.hasPrev">
 				<button data-ng-class="{{txs.page}} === 1 || {{txs.page}} === 0 ? 'btn-pagination-inactive' : 'btn-pagination'" data-ng-disabled="!txs.hasPrev" data-ng-click="txs.loadPageOffset(-1)"><i class="fas fa-caret-left fa-lg"></i></button>
 			</li>
+			<li data-ng-if="txs.currentPage" data-ng-disabled="!txs.hasPrev">
+				<button data-ng-class="{{txs.currentPage}} === 1 || {{txs.currentPage}} === 0 ? 'btn-pagination-inactive' : 'btn-pagination'" data-ng-disabled="!txs.hasPrev" data-ng-click="txs.loadPageOffset(-1)"><i class="fas fa-caret-left fa-lg"></i></button>
+			</li>
 			<li role="presentation" class="nav-item"  data-ng-repeat="page in txs.pages">
-				<a href="txs/{{page}}" data-ng-class="{{txs.page}} === {{page}} ? 'curr-page' : 'tx-other'">{{ page }}</a>
+				<a href="txs/{{page}}" data-ng-class="{{txs.page}} === {{page}} ? 'curr-page' : 'tx-other'">{{ page }}</a> 
+			</li>
+			<li data-ng-if="txs.currentPage" role="presentation" class="nav-item">
+				Page <span class="address-currpage">{{txs.currentPage}}</span>
 			</li>
 			<li data-ng-disabled="!txs.hasNext">
 				<a href="#" aria-label="Next">

--- a/src/shared/transactions-list/transactions-list.html
+++ b/src/shared/transactions-list/transactions-list.html
@@ -50,11 +50,8 @@
 	</table>
 	<nav>
 		<ul class="nav-pagination">
-			<li data-ng-if="!txs.currentPage" data-ng-disabled="!txs.hasPrev">
-				<button data-ng-class="{{txs.page}} === 1 || {{txs.page}} === 0 ? 'btn-pagination-inactive' : 'btn-pagination'" data-ng-disabled="!txs.hasPrev" data-ng-click="txs.loadPageOffset(-1)"><i class="fas fa-caret-left fa-lg"></i></button>
-			</li>
-			<li data-ng-if="txs.currentPage" data-ng-disabled="!txs.hasPrev">
-				<button data-ng-class="{{txs.currentPage}} === 1 || {{txs.currentPage}} === 0 ? 'btn-pagination-inactive' : 'btn-pagination'" data-ng-disabled="!txs.hasPrev" data-ng-click="txs.loadPageOffset(-1)"><i class="fas fa-caret-left fa-lg"></i></button>
+			<li data-ng-disabled="!txs.hasPrev">
+				<button data-ng-class="!txs.hasPrev ? 'btn-pagination-inactive' : 'btn-pagination'" data-ng-disabled="!txs.hasPrev" data-ng-click="txs.loadPageOffset(-1)"><i class="fas fa-caret-left fa-lg"></i></button>
 			</li>
 			<li role="presentation" class="nav-item"  data-ng-repeat="page in txs.pages">
 				<a href="txs/{{page}}" data-ng-class="{{txs.page}} === {{page}} ? 'curr-page' : 'tx-other'">{{ page }}</a> 
@@ -62,9 +59,9 @@
 			<li data-ng-if="txs.currentPage" role="presentation" class="nav-item">
 				Page <span class="address-currpage">{{txs.currentPage}}</span>
 			</li>
-			<li data-ng-disabled="!txs.hasNext">
+			<li data-ng-if="txs.currentPage" data-ng-disabled="!txs.hasNext">
 				<a href="#" aria-label="Next">
-					<button class="btn-pagination" data-ng-disabled="!txs.hasNext" data-ng-click="txs.loadPageOffset(1)"><i class="fas fa-caret-right fa-lg"></i></button>
+					<button data-ng-class="txs.hasNext ? 'btn-pagination' : 'btn-pagination-inactive'" data-ng-disabled="!txs.hasNext" data-ng-click="txs.loadPageOffset(1)"><i class="fas fa-caret-right fa-lg"></i></button>
 				</a>
 			</li>
 		</ul>

--- a/src/shared/transactions-list/transactions-list.html
+++ b/src/shared/transactions-list/transactions-list.html
@@ -59,7 +59,7 @@
 			<li data-ng-if="txs.currentPage" role="presentation" class="nav-item">
 				Page <span class="address-currpage">{{txs.currentPage}}</span>
 			</li>
-			<li data-ng-if="txs.currentPage" data-ng-disabled="!txs.hasNext">
+			<li data-ng-disabled="!txs.hasNext">
 				<a href="#" aria-label="Next">
 					<button data-ng-class="txs.hasNext ? 'btn-pagination' : 'btn-pagination-inactive'" data-ng-disabled="!txs.hasNext" data-ng-click="txs.loadPageOffset(1)"><i class="fas fa-caret-right fa-lg"></i></button>
 				</a>


### PR DESCRIPTION
### What was the problem?
There was no indicator for the current page at the transactions section for an account.

### How did I fix it?
Added the page indicator.

### How to test it?
Checked on the browser.

### Review checklist

* The PR solves #858 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
