### PR TITLE
Show only positive numbers for the transaction pagination - #859

### DIFF
--- a/src/components/transactions/transactions.component.js
+++ b/src/components/transactions/transactions.component.js
@@ -73,7 +73,7 @@ const TransactionsConstructor = function ($rootScope, $stateParams, $state, $htt
 		} else {
 			arr = [1, 2, 3, 4, 5];
 		}
-		return arr;
+		return arr.filter(el => el > 0);
 	};
 
 	vm.loadPageOffset = (offset) => {


### PR DESCRIPTION
### What was the problem?
- It showed negative numbers on the pagination at Transaction when the transactions had only 1 page.

### How did I fix it?
- Add a filter to a pagination function and made it show only positive numbers.

### How to test it?
- Checked on the browser.

### Review checklist

* The PR solves #859 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
