### PR TITLE
Add HTTP-based known.json source - Closes #601

### DIFF
--- a/config.js
+++ b/config.js
@@ -109,4 +109,9 @@ config.cacheDelegateAddress.enabled = true;
 // Interval in ms for checking new delegates registration (default: 60 seconds)
 config.cacheDelegateAddress.updateInterval = 60000;
 
+/*
+ * Known accounts can be loaded from the url below
+ */
+config.knownAccountsUrl = 'https://static-data.lisk.io';
+
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,8 +1728,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -12970,6 +12969,25 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -14033,6 +14051,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "qrcode-generator": "^1.2.0",
     "redis": "^2.6.2",
     "request": "^2.87.0",
+    "request-promise": "^4.2.2",
     "sigma": "https://github.com/goVanilla/sigma.js.git",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.0.3",

--- a/utils/knownAddresses.js
+++ b/utils/knownAddresses.js
@@ -15,6 +15,7 @@
  */
 const api = require('../lib/api');
 const logger = require('./logger');
+const request = require('request-promise');
 
 module.exports = function (app, config, client) {
 	const delegates = new api.delegates(app);
@@ -82,20 +83,31 @@ module.exports = function (app, config, client) {
 		this.getByAddress = async address => getFromHmset(`address:${address}`);
 		this.getByUser = async username => getFromHmset(`username:${username}`);
 
-		this.loadFromJson = () => {
+		this.loadFromServer = () => {
 			try {
-				logger.info('KnownAddresses:', 'Loading known addresses...');
-				const knownNetworks = require('../knowledge/networks.json') || {};
 				const { nethash } = app.get('nodeConstants');
-				// eslint-disable-next-line import/no-dynamic-require
-				const knownAccounts = require(`../knowledge/known_${knownNetworks[nethash]}.json`) || {};
+				let knownNetworks;
+				let knownAccounts;
 
-				Object.keys(knownAccounts).forEach((address) => {
-					client.hmset(`address:${address}`, knownAccounts[address]);
-				});
+				(async () => {
+					try {
+						logger.info('KnownAddresses:', `Loading known addresses from ${config.knownAccountsUrl}`);
+						knownNetworks = JSON.parse(await request(`${config.knownAccountsUrl}/networks.json`));
+						knownAccounts = JSON.parse(await request(`${config.knownAccountsUrl}/known_${knownNetworks[nethash]}.json`));
+					} catch (err) {
+						logger.warn('KnownAddresses:', `Failed to get known addresses from ${config.knownAccountsUrl}, falling back to the local copy`);
+						knownNetworks = require('../knowledge/networks.json') || {};
+						// eslint-disable-next-line import/no-dynamic-require
+						knownAccounts = require(`../knowledge/known_${knownNetworks[nethash]}.json`) || {};
+					}
 
-				const length = Object.keys(knownAccounts).length;
-				logger.info('KnownAddresses:', `${length} known addresses loaded`);
+					Object.keys(knownAccounts).forEach((address) => {
+						client.hmset(`address:${address}`, knownAccounts[address]);
+					});
+
+					const length = Object.keys(knownAccounts).length;
+					logger.info('KnownAddresses:', `${length} known addresses loaded`);
+				})();
 			} catch (err) {
 				logger.error('KnownAddresses: Error loading known.json:', err.message);
 			}
@@ -126,7 +138,7 @@ module.exports = function (app, config, client) {
 			if (Array.isArray(addresses)) addresses.map(key => deleteKey(key));
 			if (Array.isArray(usernames)) usernames.map(key => deleteKey(key));
 
-			this.loadFromJson();
+			this.loadFromServer();
 
 			if (config.cacheDelegateAddress.enabled) {
 				this.checkNewDelegates();


### PR DESCRIPTION
### What was the problem?
The content of the `known.json` file differs depending on the network and is independent of the Explorer release cycle.

### How did I fix it?
The `known.json` file is stored on S3 servers and can be updated independently of changes done to the Explorer codebase. In case the S3-based data are not available the local version stored in the codebase will be used.

### How to test it?
Adjust config.json accordingly and run the application. On Mainnet, there should be visible correct names in `Top Accounts`.

### Review checklist

* The PR solves #601
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
