### PR TITLE
Display warning if explorer is stuck - Closes #74

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -407,3 +407,7 @@
   50% { left: 50%; }
   100% { left: 0%; }
 }
+
+.not-connected {
+  color: red;
+}

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -409,5 +409,11 @@
 }
 
 .not-connected {
-  color: red;
+  color: #eb1e1e;
+  padding-left: 27px;
+}
+
+.connected {
+  color: #0de42a;
+  padding-left: 27px;
 }

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -207,6 +207,10 @@
   background-color: rgb(1, 56, 115);
 }
 
+.navbar-fixed-top .socket-disconnected {
+  background-color: #881111;
+}
+
 .navbar-fixed-top .network-status .flex-container {
   background: rgb(1, 56, 115);
   padding: 8px 12px;
@@ -217,6 +221,10 @@
   flex-wrap: wrap;
   flex: 0 1 auto;
   justify-content: space-between;
+}
+
+.navbar-fixed-top .socket-disconnected .flex-container {
+  background: #881111;
 }
 
 .navbar-fixed-top .main-header {

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -410,10 +410,10 @@
 
 .not-connected {
   color: #eb1e1e;
-  padding-left: 27px;
+  padding-left: 12px;
 }
 
 .connected {
   color: #0de42a;
-  padding-left: 27px;
+  padding-left: 12px;
 }

--- a/src/components/header/header.directive.js
+++ b/src/components/header/header.directive.js
@@ -16,13 +16,12 @@
 import AppHeader from './header.module';
 import template from './header.html';
 import './header.css';
-
 /**
  *
  * @todo Fix the service usage
  *
  */
-AppHeader.directive('mainHeader', ($socket, $rootScope, Header) => {
+AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 	const HeaderLink = () => {
 		$rootScope.currency = {
 			symbol: 'LSK',
@@ -47,14 +46,16 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header) => {
 		});
 
 		const events = ['connect', 'connect_error', 'error', 'disconnect', 'reconnect', 'reconnect_error', 'reconnect_failed'];
+
 		const registerSocketEvents = (arr) => {
 			arr.forEach((e) => {
 				ns.on(e, () => {
-					if (e === 'connected' || e === 'reconnect') $rootScope.connected = true;
-					else $rootScope.connected = false;
+					if (e === 'connect' || e === 'reconnect') $rootScope.connected = true;
+					else $timeout(() => $rootScope.connected = false, 4000);
 				});
 			});
 		};
+
 		registerSocketEvents(events);
 
 		$rootScope.$on('$destroy', () => {

--- a/src/components/header/header.directive.js
+++ b/src/components/header/header.directive.js
@@ -49,20 +49,36 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 			if (res.ticker) { header.updatePriceTicker(res.ticker); }
 		});
 
-		const events = ['connect', 'connect_error', 'error', 'disconnect', 'reconnect', 'reconnect_error', 'reconnect_failed'];
+		const events = [
+			'connect',
+			'connect_error',
+			'error',
+			'disconnect',
+			'reconnect',
+			'reconnect_error',
+			'reconnect_failed',
+		];
 
 		const registerSocketEvents = (arr) => {
+			const reconnect = () => {
+				$rootScope.connectionMsg = true;
+				$timeout(() => $rootScope.connectionMsg = false, 2000);
+			};
+
+			const disconnect = () => {
+				$timeout(() => $rootScope.connected = false, 5000);
+				$timeout(() => $rootScope.connectionErrorMsg = true, 5000);
+				$timeout(() => $rootScope.connectionErrorMsg = false, 7000);
+			};
+
 			arr.forEach((e) => {
 				ns.on(e, () => {
 					if (e === 'connect') {
 						$rootScope.connected = true;
-					} else if (e === 'reconnect') {
-						$rootScope.connectionMsg = true;
-						$timeout(() => $rootScope.connectionMsg = false, 2000);
 					} else if (e === 'disconnect') {
-						$timeout(() => $rootScope.connectionErrorMsg = true, 5000);
-						$timeout(() => $rootScope.connectionErrorMsg = false, 7000);
-						$timeout(() => $rootScope.connected = false, 5000);
+						disconnect();
+					} else if (e === 'reconnect') {
+						reconnect();
 					} else {
 						$timeout(() => $rootScope.connected = false, 5000);
 					}

--- a/src/components/header/header.directive.js
+++ b/src/components/header/header.directive.js
@@ -39,9 +39,23 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header) => {
 		const ns = $socket('/header');
 
 		ns.on('data', (res) => {
-			if (res.status) { header.updateBlockStatus(res.status); }
+			if (res.status) {
+				header.updateBlockStatus(res.status);
+				$rootScope.connected = true;
+			}
 			if (res.ticker) { header.updatePriceTicker(res.ticker); }
 		});
+
+		const events = ['connect', 'connect_error', 'error', 'disconnect', 'reconnect', 'reconnect_error', 'reconnect_failed'];
+		const registerSocketEvents = (arr) => {
+			arr.forEach((e) => {
+				ns.on(e, () => {
+					if (e === 'connected' || e === 'reconnect') $rootScope.connected = true;
+					else $rootScope.connected = false;
+				});
+			});
+		};
+		registerSocketEvents(events);
 
 		$rootScope.$on('$destroy', () => {
 			ns.removeAllListeners();

--- a/src/components/header/header.directive.js
+++ b/src/components/header/header.directive.js
@@ -28,6 +28,7 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 		};
 
 		$rootScope.connected = true;
+		$rootScope.connectionErrorMsg = false;
 		$rootScope.connectionMsg = false;
 
 		$rootScope.showNethash = (hash) => {
@@ -53,9 +54,18 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 		const registerSocketEvents = (arr) => {
 			arr.forEach((e) => {
 				ns.on(e, () => {
-					if (e === 'connect' || e === 'reconnect') $rootScope.connected = true;
-					else $timeout(() => $rootScope.connected = false, 5000);
-					if (!$rootScope.connected) $rootScope.connectionMsg = true;
+					if (e === 'connect') {
+						$rootScope.connected = true;
+					} else if (e === 'reconnect') {
+						$rootScope.connectionMsg = true;
+						$timeout(() => $rootScope.connectionMsg = false, 2000);
+					} else if (e === 'disconnect') {
+						$timeout(() => $rootScope.connectionErrorMsg = true, 5000);
+						$timeout(() => $rootScope.connectionErrorMsg = false, 7000);
+						$timeout(() => $rootScope.connected = false, 5000);
+					} else {
+						$timeout(() => $rootScope.connected = false, 5000);
+					}
 				});
 			});
 		};

--- a/src/components/header/header.directive.js
+++ b/src/components/header/header.directive.js
@@ -27,6 +27,9 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 			symbol: 'LSK',
 		};
 
+		$rootScope.connected = true;
+		$rootScope.connectionMsg = false;
+
 		$rootScope.showNethash = (hash) => {
 			if (typeof hash === 'string' && hash.length > 0) {
 				return hash.toLowerCase() !== 'mainnet';
@@ -51,7 +54,8 @@ AppHeader.directive('mainHeader', ($socket, $rootScope, Header, $timeout) => {
 			arr.forEach((e) => {
 				ns.on(e, () => {
 					if (e === 'connect' || e === 'reconnect') $rootScope.connected = true;
-					else $timeout(() => $rootScope.connected = false, 4000);
+					else $timeout(() => $rootScope.connected = false, 5000);
+					if (!$rootScope.connected) $rootScope.connectionMsg = true;
 				});
 			});
 		};

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -90,6 +90,12 @@
 			</div>
 		</div>
 	</nav>
-	<div data-ng-show="connectionErrorMsg" class="not-connected">not connected</div>
-	<div data-ng-show="connectionMsg" class="connected">connected</div>
+	<div>
+		<div class="container">
+			<div class="flex-container">
+				<div data-ng-show="connectionErrorMsg" class="not-connected">not connected</div>
+				<div data-ng-show="connectionMsg" class="connected">connected</div>
+			</div>
+		</div>
+	</div>
 </div>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -70,8 +70,18 @@
 			</div>
 		</div>
 	</nav>
-	<nav class="network-status">
-		<div class="container fadein" data-ng-show="blockStatus">
+	<nav class="network-status" data-ng-if="connected">
+		<div class="container fadein">
+			<div class="flex-container">
+				<span class="height"><b>Height:</b> {{blockStatus.height | number:0}}</span>
+				<span class="supply"><b>Supply:</b> {{blockStatus.supply | lisk | number:0}}</span>
+				<span class="lisk-btc"><b>LSK/BTC:</b> {{currency.tickers.LSK.BTC || 'N/A'}}</span>
+				<span class="lisk-usd"><b>LSK/{{currency.tickers.LSK[currency.symbol] && currency.symbol !== 'BTC' ? currency.symbol : 'USD'}}:</b> {{currency.tickers.LSK[currency.symbol] && currency.symbol !== 'BTC' ? (currency.tickers.LSK[currency.symbol] | number:4) : (currency.tickers.LSK.USD | number:4) || 'N/A'}}</span>
+			</div>
+		</div>
+	</nav>
+	<nav class="network-status socket-disconnected" data-ng-if="!connected">
+		<div class="container fadein">
 			<div class="flex-container">
 				<span class="height"><b>Height:</b> {{blockStatus.height | number:0}}</span>
 				<span class="supply"><b>Supply:</b> {{blockStatus.supply | lisk | number:0}}</span>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -90,4 +90,5 @@
 			</div>
 		</div>
 	</nav>
+	<div data-ng-show="connectionMsg" class="not-connected">not connected</div>
 </div>

--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -90,5 +90,6 @@
 			</div>
 		</div>
 	</nav>
-	<div data-ng-show="connectionMsg" class="not-connected">not connected</div>
+	<div data-ng-show="connectionErrorMsg" class="not-connected">not connected</div>
+	<div data-ng-show="connectionMsg" class="connected">connected</div>
 </div>


### PR DESCRIPTION
### What was the problem?
- User should see instantly if there is something wrong with explorer, we can use some effect on header for that (red background, red blinking height, etc.).

### How did I fix it?
- Added function that registers events for web-sockets and displays the corresponding background and message, depending on the event.

### How to test it?
- Checked on chrome.

### Review checklist

* The PR solves #74 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
