### PR TITLE
Improvements on Dockerfile - Closes #889

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,18 @@
 FROM node:8 AS builder
 
-RUN useradd --create-home lisk && \
-    apt-get update && \
-    apt-get install -y nasm && \
-    npm install --global bower
-# As of Mai 2018 cloud.docker.com runs docker 17.06.1-ce
-# however v17.12 is required to use the chown flag
-#COPY --chown=lisk:lisk . /home/lisk/lisk-explorer/
-COPY . /home/lisk/lisk-explorer/
-RUN chown lisk:lisk --recursive /home/lisk/lisk-explorer
-
-USER lisk
+RUN useradd --create-home lisk
+COPY --chown=lisk:lisk ./package-lock.json ./package.json /home/lisk/lisk-explorer/
 WORKDIR /home/lisk/lisk-explorer
-RUN npm install && \
-    npm run build
+USER lisk
+RUN npm ci
+COPY --chown=lisk:lisk . /home/lisk/lisk-explorer/
+RUN npm run build
 
 
 FROM node:8-alpine
 
-RUN adduser -D lisk 
-#COPY --chown=lisk:lisk --from=builder /home/lisk/lisk-explorer /home/lisk/lisk-explorer/
-COPY --from=builder /home/lisk/lisk-explorer /home/lisk/lisk-explorer/
-RUN chown lisk:lisk --recursive /home/lisk/lisk-explorer
+RUN adduser -D lisk
+COPY --chown=lisk:lisk --from=builder /home/lisk/lisk-explorer /home/lisk/lisk-explorer/
 
 USER lisk
 WORKDIR /home/lisk/lisk-explorer


### PR DESCRIPTION
- Removed bower and nasm
- Use of COPY with --chown argument
- Use npm ci instead of npm install
- Added stage to install dependencies before copy source code, so the
  layer with deps can be cached.

### What was the problem?

### How did I fix it?

### How to test it?

### Review checklist

* The PR solves #889 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
