### PR TITLE
Modify text alignment for Transaction type 0 - Closes #892

### DIFF
--- a/src/components/transactions/transaction.html
+++ b/src/components/transactions/transaction.html
@@ -101,8 +101,8 @@
 							<tr>
 								<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right"><span>Data text</span></td>
 								<td class="right-padding-xs right-padding-s right-padding-m right-padding-l double text-right">
-									<span class="pull-right" style="font-family: monospace;" data-ng-if="vm.tx.asset.data">{{vm.tx.asset.data}}</span>
-									<span class="pull-right" data-ng-if="!vm.tx.asset.data"><i>(no data)</i></span>
+									<span style="font-family: monospace;" data-ng-if="vm.tx.asset.data">{{vm.tx.asset.data}}</span>
+									<span data-ng-if="!vm.tx.asset.data"><i>(no data)</i></span>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
### What was the problem?
- The text included in the transaction type 0 in Transaction details may cover the label.

### How did I fix it?
- Removed unnecessary class.

### How to test it?
- Checked on Chrome.

### Review checklist

* The PR solves #892 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
