### PR TITLE
Align response data of Delegates API - Closes #894

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -80,12 +80,12 @@ module.exports = function (app) {
 	function transactionsMapper(o) {
 		if (!o) return {};
 		return {
-			amount: o.amount,
+			amount: Number(o.amount),
 			asset: o.asset,
 			blockId: o.blockId,
 			confirmations: o.confirmations,
 			delegate: o.delegate,
-			fee: o.fee,
+			fee: Number(o.fee),
 			height: o.height,
 			id: o.id,
 			recipientId: o.recipientId,


### PR DESCRIPTION
### What was the problem?
The data type of amount and fee that are created in the transaction mapper in the delegates API are string while they are number in the transactions API. They should be aligned.

### How did I fix it?
Added Number() function at amount and fee in the transaction mapper.

### How to test it?
Run grunt test and e2e test.

### Review checklist

* The PR solves #894 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
