### PR TITLE
Search improvements - Closes #898

### DIFF
--- a/api/common.js
+++ b/api/common.js
@@ -24,6 +24,11 @@ module.exports = [
 		params: req => req.query.id,
 	},
 	{
+		path: 'unifiedSearch',
+		service: '',
+		params: req => req.query.q,
+	},
+	{
 		path: 'ui_message',
 		service: '',
 		params: () => undefined,

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -24,8 +24,15 @@ Feature: Top menu
     And I fill in "genesis_17" to "search" field in "desktop search" div
     And I hit "enter" in "search" field in "desktop search" div
     And I wait 1 seconds
-    And I click "search suggestion item" #1 in "desktop search" div
     Then I should be on page "/address/537318935439898807L"
+
+  Scenario: should allow to show a delegate list
+    Given I'm on page "/"
+    And I fill in "genesis" to "search" field in "desktop search" div
+    And I hit "enter" in "search" field in "desktop search" div
+    And I wait 1 seconds
+    And I click "search suggestion item" #1 in "desktop search" div
+    Then I should be on page "/address/12254605294831056546L"
 
   Scenario: should show an error message on invalid input
     Given I'm on page "/"

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -13,90 +13,105 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const async = require('async');
+
 module.exports = function (app, api) {
 	this.nodeConstants = () => app.get('nodeConstants');
 	this.version = () => ({ version: app.get('version') });
 
 	const exchange = app.exchange;
-	const addressReg = /^[0-9]{1,21}[L|l]$/;
-	const publicKeyReg = /^[0-9a-f]{64}$/;
-	const usernameReg = /[a-z!@$&_.]/;
+	// const addressReg = /^[0-9]{1,21}[L|l]$/;
+	// const publicKeyReg = /^[0-9a-f]{64}$/;
+	// const usernameReg = /[a-z!@$&_.]/;
 
-	const searchDelegates = function (id, error, success) {
+	const searchDelegatesFullText = function (id, cb) {
 		const delegates = new api.delegates(app);
 		delegates.getSearch(
 			id,
-			body => error({ success: false, error: body.error }),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && Array.isArray(body.results)) {
-					return success({ success: true, result: { type: 'delegate', delegates: body.results } });
+					return cb(null, { success: true, result: { type: 'delegate', delegates: body.results } });
 				}
-				return error({ success: false, error: null, found: false });
+				return cb(null, { success: false, error: null, found: false });
 			});
 	};
 
-	const searchAccount = function (id, error, success) {
+	const searchDelegatesStrict = function (id, cb) {
+		const delegates = new api.delegates(app);
+		delegates.getSearch(
+			id,
+			body => cb(null, { success: false, error: body.error }),
+			(body) => {
+				if (body && Array.isArray(body.results)) {
+					return cb(null, { success: true, result: { type: 'delegate', delegates: body.results } });
+				}
+				return cb(null, { success: false, error: null, found: false });
+			});
+	};
+
+	const searchAccount = function (id, cb) {
 		const accounts = new api.accounts(app);
 		accounts.getAccount(
 			{ address: id },
-			body => error({ success: false, error: body.error }),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && body.address) {
-					return success({ success: true, result: { type: 'address', id: body.address } });
+					return cb(null, { success: true, result: { type: 'address', id: body.address } });
 				}
-				return error({ success: false, error: null, found: false });
+				return cb(null, { success: false, error: null, found: false });
 			});
 	};
 
-	const searchPublicKey = function (id, error, success) {
+	const searchPublicKey = function (id, cb) {
 		const accounts = new api.accounts(app);
 		accounts.getAccount(
 			{ publicKey: id },
-			body => error({ success: false, error: body.error }),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && body.address) {
-					return success({ success: true, result: { type: 'address', id: body.address } });
+					return cb(null, { success: true, result: { type: 'address', id: body.address } });
 				}
-				return error({ success: false, error: null, found: false });
+				return cb(null, { success: false, error: null, found: false });
 			});
 	};
 
-	const searchTransaction = function (id, error, success) {
+	const searchTransaction = function (id, cb) {
 		const transactions = new api.transactions(app);
 		transactions.getTransaction(
 			id,
-			() => searchDelegates(id, error, success),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && body.transaction) {
-					return success({ success: true, result: { type: 'tx', id: body.transaction.id } });
+					return cb(null, { success: true, result: { type: 'tx', id: body.transaction.id } });
 				}
-				return error({ success: false, error: body.error });
+				return cb(null, { success: false, error: body.error });
 			});
 	};
 
-	const searchBlock = function (id, error, success) {
+	const searchBlock = function (id, cb) {
 		const blocks = new api.blocks(app);
 		blocks.getBlock(
 			id,
-			() => searchTransaction(id, error, success),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && body.block) {
-					return success({ success: true, result: { type: 'block', id: body.block.id } });
+					return cb(null, { success: true, result: { type: 'block', id: body.block.id, height: body.block.height } });
 				}
-				return error({ success: false, error: body.error });
+				return cb(null, { success: false, error: body.error });
 			});
 	};
 
-	const searchHeight = function (id, error, success) {
+	const searchHeight = function (id, cb) {
 		const blocks = new api.blocks(app);
 		blocks.getHeight(
 			id,
-			() => searchBlock(id, error, success),
+			body => cb(null, { success: false, error: body.error }),
 			(body) => {
 				if (body && body.block) {
-					return success({ success: true, result: { type: 'block', id: body.block.id } });
+					return cb(null, { success: true, result: { type: 'block', id: body.block.id, height: body.block.height } });
 				}
-				return error({ success: false, error: body.error });
+				return cb(null, { success: false, error: body.error });
 			});
 	};
 
@@ -110,17 +125,46 @@ module.exports = function (app, api) {
 		return success({ success: false, error: 'Exchange rates are disabled' });
 	};
 
-	this.search = function (id, error, success) {
-		if (id === null) {
+	this.search = function (query, error, success) {
+		if (query === null) {
 			return error({ success: false, error: 'Missing/Invalid search criteria' });
-		} else if (addressReg.test(id)) {
-			return searchAccount(id, error, success);
-		} else if (publicKeyReg.test(id)) {
-			return searchPublicKey(id, error, success);
-		} else if (usernameReg.test(id)) {
-			return searchDelegates(id, error, success);
 		}
-		return searchHeight(id, error, success);
+
+		return async.parallel([
+			async.apply(searchAccount, query),
+			async.apply(searchPublicKey, query),
+			async.apply(searchDelegatesFullText, query),
+			// async.apply(searchDelegatesStrict, query),
+			async.apply(searchHeight, query),
+			async.apply(searchTransaction, query),
+			async.apply(searchBlock, query),
+		], (err, results) => {
+			const searchResults = [];
+			Object.keys(results).forEach((i) => {
+				const group = results[i];
+				if (group.success === true) {
+					if (group.result.type === 'delegate') {
+						group.result.delegates.forEach((item) => {
+							searchResults.push({
+								name: item.username,
+								address: item.address,
+								type: group.result.type,
+								accuracy: item.similarity,
+							});
+						});
+					} else if (group.result.type === 'address' || group.result.type === 'block' || group.result.type === 'tx') {
+						searchResults.push({
+							name: group.result.id,
+							type: group.result.type,
+							height: group.result.height,
+							accuracy: 1,
+						});
+					}
+				}
+			});
+			// searchResults.sort();
+			success({ success: true, result: searchResults });
+		});
 	};
 
 	this.ui_message = function (query, error, success) {

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -39,7 +39,7 @@ module.exports = function (app, api) {
 
 	const searchDelegatesStrict = function (id, cb) {
 		const delegates = new api.delegates(app);
-		delegates.getSearch(
+		delegates.getStrictSearch(
 			id,
 			body => cb(null, { success: false, error: body.error }),
 			(body) => {
@@ -134,7 +134,7 @@ module.exports = function (app, api) {
 			async.apply(searchAccount, query),
 			async.apply(searchPublicKey, query),
 			async.apply(searchDelegatesFullText, query),
-			// async.apply(searchDelegatesStrict, query),
+			async.apply(searchDelegatesStrict, query),
 			async.apply(searchHeight, query),
 			async.apply(searchTransaction, query),
 			async.apply(searchBlock, query),
@@ -162,7 +162,7 @@ module.exports = function (app, api) {
 					}
 				}
 			});
-			// searchResults.sort();
+			searchResults.sort((a, b) => b.accuracy - a.accuracy);
 			success({ success: true, result: searchResults });
 		});
 	};

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -155,8 +155,8 @@ module.exports = function (app, api) {
 						group.result.delegates.forEach((item) => {
 							searchResults.push({
 								id: item.address,
-								username: item.username,
-								type: group.result.type,
+								description: item.username,
+								type: 'address',
 								accuracy: item.similarity,
 							});
 						});
@@ -164,7 +164,7 @@ module.exports = function (app, api) {
 						searchResults.push({
 							id: group.result.id,
 							type: group.result.type,
-							height: group.result.height,
+							description: group.result.height,
 							accuracy: 1,
 						});
 					}

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -125,6 +125,14 @@ module.exports = function (app, api) {
 		return success({ success: false, error: 'Exchange rates are disabled' });
 	};
 
+	const removeDuplicates = (origArr) => {
+		const newObj = {};
+		origArr.forEach((item) => {
+			newObj[`${item.type}${item.id}`] = item;
+		});
+		return Object.keys(newObj).map(item => newObj[item]);
+	};
+
 	this.search = function (query, error, success) {
 		if (query === null) {
 			return error({ success: false, error: 'Missing/Invalid search criteria' });
@@ -146,15 +154,15 @@ module.exports = function (app, api) {
 					if (group.result.type === 'delegate') {
 						group.result.delegates.forEach((item) => {
 							searchResults.push({
-								name: item.username,
-								address: item.address,
+								id: item.address,
+								username: item.username,
 								type: group.result.type,
 								accuracy: item.similarity,
 							});
 						});
 					} else if (group.result.type === 'address' || group.result.type === 'block' || group.result.type === 'tx') {
 						searchResults.push({
-							name: group.result.id,
+							id: group.result.id,
 							type: group.result.type,
 							height: group.result.height,
 							accuracy: 1,
@@ -162,8 +170,9 @@ module.exports = function (app, api) {
 					}
 				}
 			});
-			searchResults.sort((a, b) => b.accuracy - a.accuracy);
-			success({ success: true, result: searchResults });
+			const searchResultsWoDupes = removeDuplicates(searchResults);
+			searchResultsWoDupes.sort((a, b) => b.accuracy - a.accuracy);
+			success({ success: true, result: searchResultsWoDupes });
 		});
 	};
 

--- a/lib/api/common.js
+++ b/lib/api/common.js
@@ -20,11 +20,102 @@ module.exports = function (app, api) {
 	this.version = () => ({ version: app.get('version') });
 
 	const exchange = app.exchange;
-	// const addressReg = /^[0-9]{1,21}[L|l]$/;
-	// const publicKeyReg = /^[0-9a-f]{64}$/;
-	// const usernameReg = /[a-z!@$&_.]/;
+	const addressReg = /^[0-9]{1,21}[L|l]$/;
+	const publicKeyReg = /^[0-9a-f]{64}$/;
+	const usernameReg = /[a-z!@$&_.]/;
 
-	const searchDelegatesFullText = function (id, cb) {
+	const searchDelegates = function (id, error, success) {
+		const delegates = new api.delegates(app);
+		delegates.getSearch(
+			id,
+			body => error({ success: false, error: body.error }),
+			(body) => {
+				if (body && Array.isArray(body.results)) {
+					return success({ success: true, result: { type: 'delegate', delegates: body.results } });
+				}
+				return error({ success: false, error: null, found: false });
+			});
+	};
+
+	const searchAccount = function (id, error, success) {
+		const accounts = new api.accounts(app);
+		accounts.getAccount(
+			{ address: id },
+			body => error({ success: false, error: body.error }),
+			(body) => {
+				if (body && body.address) {
+					return success({ success: true, result: { type: 'address', id: body.address } });
+				}
+				return error({ success: false, error: null, found: false });
+			});
+	};
+
+	const searchPublicKey = function (id, error, success) {
+		const accounts = new api.accounts(app);
+		accounts.getAccount(
+			{ publicKey: id },
+			body => error({ success: false, error: body.error }),
+			(body) => {
+				if (body && body.address) {
+					return success({ success: true, result: { type: 'address', id: body.address } });
+				}
+				return error({ success: false, error: null, found: false });
+			});
+	};
+
+	const searchTransaction = function (id, error, success) {
+		const transactions = new api.transactions(app);
+		transactions.getTransaction(
+			id,
+			() => searchDelegates(id, error, success),
+			(body) => {
+				if (body && body.transaction) {
+					return success({ success: true, result: { type: 'tx', id: body.transaction.id } });
+				}
+				return error({ success: false, error: body.error });
+			});
+	};
+
+	const searchBlock = function (id, error, success) {
+		const blocks = new api.blocks(app);
+		blocks.getBlock(
+			id,
+			() => searchTransaction(id, error, success),
+			(body) => {
+				if (body && body.block) {
+					return success({ success: true, result: { type: 'block', id: body.block.id } });
+				}
+				return error({ success: false, error: body.error });
+			});
+	};
+
+	const searchHeight = function (id, error, success) {
+		const blocks = new api.blocks(app);
+		blocks.getHeight(
+			id,
+			() => searchBlock(id, error, success),
+			(body) => {
+				if (body && body.block) {
+					return success({ success: true, result: { type: 'block', id: body.block.id } });
+				}
+				return error({ success: false, error: body.error });
+			});
+	};
+
+	this.search = function (id, error, success) {
+		if (id === null) {
+			return error({ success: false, error: 'Missing/Invalid search criteria' });
+		} else if (addressReg.test(id)) {
+			return searchAccount(id, error, success);
+		} else if (publicKeyReg.test(id)) {
+			return searchPublicKey(id, error, success);
+		} else if (usernameReg.test(id)) {
+			return searchDelegates(id, error, success);
+		}
+		return searchHeight(id, error, success);
+	};
+
+	const newSearchDelegatesFullText = function (id, cb) {
 		const delegates = new api.delegates(app);
 		delegates.getSearch(
 			id,
@@ -37,7 +128,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchDelegatesStrict = function (id, cb) {
+	const newSearchDelegatesStrict = function (id, cb) {
 		const delegates = new api.delegates(app);
 		delegates.getStrictSearch(
 			id,
@@ -50,7 +141,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchAccount = function (id, cb) {
+	const newSearchAccount = function (id, cb) {
 		const accounts = new api.accounts(app);
 		accounts.getAccount(
 			{ address: id },
@@ -63,7 +154,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchPublicKey = function (id, cb) {
+	const newSearchPublicKey = function (id, cb) {
 		const accounts = new api.accounts(app);
 		accounts.getAccount(
 			{ publicKey: id },
@@ -76,7 +167,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchTransaction = function (id, cb) {
+	const newSearchTransaction = function (id, cb) {
 		const transactions = new api.transactions(app);
 		transactions.getTransaction(
 			id,
@@ -89,7 +180,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchBlock = function (id, cb) {
+	const newSearchBlock = function (id, cb) {
 		const blocks = new api.blocks(app);
 		blocks.getBlock(
 			id,
@@ -102,7 +193,7 @@ module.exports = function (app, api) {
 			});
 	};
 
-	const searchHeight = function (id, cb) {
+	const newSearchHeight = function (id, cb) {
 		const blocks = new api.blocks(app);
 		blocks.getHeight(
 			id,
@@ -115,16 +206,6 @@ module.exports = function (app, api) {
 			});
 	};
 
-	this.getPriceTicker = function (query, error, success) {
-		if (app.get('exchange enabled')) {
-			// If exchange rates are enabled - that endpoint cannot fail,
-			// in worst case we return empty object here
-			return success({ success: true, tickers: exchange.tickers });
-		}
-		// We use success callback here on purpose
-		return success({ success: false, error: 'Exchange rates are disabled' });
-	};
-
 	const removeDuplicates = (origArr) => {
 		const newObj = {};
 		origArr.forEach((item) => {
@@ -133,19 +214,19 @@ module.exports = function (app, api) {
 		return Object.keys(newObj).map(item => newObj[item]);
 	};
 
-	this.search = function (query, error, success) {
+	this.unifiedSearch = function (query, error, success) {
 		if (query === null) {
 			return error({ success: false, error: 'Missing/Invalid search criteria' });
 		}
 
 		return async.parallel([
-			async.apply(searchAccount, query),
-			async.apply(searchPublicKey, query),
-			async.apply(searchDelegatesFullText, query),
-			async.apply(searchDelegatesStrict, query),
-			async.apply(searchHeight, query),
-			async.apply(searchTransaction, query),
-			async.apply(searchBlock, query),
+			async.apply(newSearchAccount, query),
+			async.apply(newSearchPublicKey, query),
+			async.apply(newSearchDelegatesFullText, query),
+			async.apply(newSearchDelegatesStrict, query),
+			async.apply(newSearchHeight, query),
+			async.apply(newSearchTransaction, query),
+			async.apply(newSearchBlock, query),
 		], (err, results) => {
 			const searchResults = [];
 			Object.keys(results).forEach((i) => {
@@ -174,6 +255,16 @@ module.exports = function (app, api) {
 			searchResultsWoDupes.sort((a, b) => b.accuracy - a.accuracy);
 			success({ success: true, result: searchResultsWoDupes });
 		});
+	};
+
+	this.getPriceTicker = function (query, error, success) {
+		if (app.get('exchange enabled')) {
+			// If exchange rates are enabled - that endpoint cannot fail,
+			// in worst case we return empty object here
+			return success({ success: true, tickers: exchange.tickers });
+		}
+		// We use success callback here on purpose
+		return success({ success: false, error: 'Exchange rates are disabled' });
 	};
 
 	this.ui_message = function (query, error, success) {

--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -487,12 +487,37 @@ module.exports = function (app) {
 		});
 	};
 
-	this.getSearch = function (params, error, success) {
+	this.getSearch = function (params, error, success) { // Full text search
 		if (!params || !params.match(/^(?![0-9]{1,21}[L]$)[0-9a-z.]+/i)) {
 			return error({ success: false, error: 'Missing/Invalid username parameter' });
 		}
 		return request.get({
 			url: `${app.get('lisk address')}/delegates?search=${params}`,
+			json: true,
+		}, (err, response, body) => {
+			if (response.statusCode !== 200) {
+				return error({ success: false, error: 'Bad response from Core' });
+			}
+			if (!body.data || !body.data[0]) {
+				return error({ success: false, error: 'Delegate not found' });
+			}
+
+			const results = body.data.map(delegate => ({
+				address: delegate.address || delegate.account.address,
+				username: delegate.username,
+				similarity: stringSimilarity.compareTwoStrings(params, delegate.username),
+			})).sort((a, b) => b.similarity - a.similarity);
+
+			return success({ success: true, results });
+		});
+	};
+
+	this.getStrictSearch = function (params, error, success) { // Full text search
+		if (!params || !params.match(/^(?![0-9]{1,21}[L]$)[0-9a-z.]+/i)) {
+			return error({ success: false, error: 'Missing/Invalid username parameter' });
+		}
+		return request.get({
+			url: `${app.get('lisk address')}/delegates?username=${params}`,
 			json: true,
 		}, (err, response, body) => {
 			if (response.statusCode !== 200) {

--- a/src/components/search/search.directive.js
+++ b/src/components/search/search.directive.js
@@ -61,9 +61,9 @@ AppSearch.directive('search', ($stateParams, $location, $timeout, Global, $http)
 			this.loading = true;
 			sch.showingResults = false;
 
-			$http.get('/api/search', {
+			$http.get('/api/unifiedSearch', {
 				params: {
-					id: this.q,
+					q: this.q,
 				},
 			}).then((resp) => {
 				sch.loading = false;

--- a/src/components/search/search.directive.js
+++ b/src/components/search/search.directive.js
@@ -67,7 +67,7 @@ AppSearch.directive('search', ($stateParams, $location, $timeout, Global, $http)
 				},
 			}).then((resp) => {
 				sch.loading = false;
-				if (resp.data.success === false) {
+				if (resp.data.success === false || resp.data.result.length === 0) {
 					_badQuery();
 				} else if (resp.data.result.length === 1) {
 					_resetSearch();

--- a/src/components/search/search.directive.js
+++ b/src/components/search/search.directive.js
@@ -69,12 +69,12 @@ AppSearch.directive('search', ($stateParams, $location, $timeout, Global, $http)
 				sch.loading = false;
 				if (resp.data.success === false) {
 					_badQuery();
-				} else if (resp.data.result.id) {
+				} else if (resp.data.result.length === 1) {
 					_resetSearch();
 
-					$location.path(`/${resp.data.result.type}/${resp.data.result.id}`);
-				} else if (resp.data.result.delegates) {
-					sch.results = resp.data.result.delegates.slice(0, 5);
+					$location.path(`/${resp.data.result[0].type}/${resp.data.result[0].id}`);
+				} else {
+					sch.results = resp.data.result.slice(0, 8);
 					sch.showingResults = true;
 				}
 			});

--- a/src/components/search/search.html
+++ b/src/components/search/search.html
@@ -22,13 +22,13 @@
 		<span class="glyphicon" aria-hidden="true" data-ng-mousedown="sch.onSearchIconClick()" data-ng-class="{'glyphicon-remove': sch.mobileView && sch.activeForm, 'glyphicon-search': !sch.mobileView || !sch.activeForm}"></span>
 		<div class="search-suggestion-list list-group"
 			ng-if="sch.showingResults && sch.results">
-			<a href="/address/{{result.address}}" class="search-suggestion-item list-group-item list-group-item-action flex-column align-items-start"
-				ng-repeat="result in sch.results" ng-class="result.similarity === 1 ? 'match' : ''">
+			<a href="/{{result.type}}/{{result.id}}" class="search-suggestion-item list-group-item list-group-item-action flex-column align-items-start"
+				ng-repeat="result in sch.results" ng-class="result.accuracy === 1 ? 'match' : ''">
 				<div class="d-flex w-100 justify-content-between">
-					<h5 class="mb-1">{{result.address}}</h5>
-					<small ng-if='result.similarity === 1'>Matching result</small>
+					<h5 class="mb-1">{{result.id}}</h5>
+					<small ng-if='result.accuracy === 1'>Matching result</small>
 				</div>
-				<p class="mb-1">{{result.username}}</p>
+				<p class="mb-1">{{result.description || 'No additional info'}}<small class="pull-right">{{result.type}}</small></p>
 			</a>
 			<span class="arrow"></span>
 		</div>

--- a/test/api/common.js
+++ b/test/api/common.js
@@ -61,8 +61,8 @@ describe('Common API', () => {
 		it('using known block should be ok', (done) => {
 			getSearch(params.blockId, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('block');
-				node.expect(res.body.result.id).to.equal(params.blockId);
+				node.expect(res.body.result[0].type).to.equal('block');
+				node.expect(res.body.result[0].id).to.equal(params.blockId);
 				done();
 			});
 		});
@@ -70,8 +70,8 @@ describe('Common API', () => {
 		it('using known height should be ok', (done) => {
 			getSearch('1', (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('block');
-				node.expect(res.body.result.id).to.equal(params.blockId);
+				node.expect(res.body.result[0].type).to.equal('block');
+				node.expect(res.body.result[0].id).to.equal(params.blockId);
 				done();
 			});
 		});
@@ -79,8 +79,8 @@ describe('Common API', () => {
 		it('using known address should be ok', (done) => {
 			getSearch(params.address, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('address');
-				node.expect(res.body.result.id).to.equal(params.address);
+				node.expect(res.body.result[0].type).to.equal('address');
+				node.expect(res.body.result[0].id).to.equal(params.address);
 				done();
 			});
 		});
@@ -88,8 +88,8 @@ describe('Common API', () => {
 		it('using known transaction should be ok', (done) => {
 			getSearch(params.tx, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('tx');
-				node.expect(res.body.result.id).to.equal(params.tx);
+				node.expect(res.body.result[0].type).to.equal('tx');
+				node.expect(res.body.result[0].id).to.equal(params.tx);
 				done();
 			});
 		});
@@ -97,8 +97,8 @@ describe('Common API', () => {
 		it('using known delegate should be ok', (done) => {
 			getSearch(params.username, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('delegate');
-				node.expect(res.body.result.delegates[0].address).to.equal(params.address);
+				node.expect(res.body.result[0].type).to.equal('address');
+				node.expect(res.body.result[0].id).to.equal(params.address);
 				done();
 			});
 		});
@@ -107,17 +107,17 @@ describe('Common API', () => {
 			const partialName = 'gene';
 			getSearch(partialName, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
-				node.expect(res.body.result.type).to.equal('delegate');
-				res.body.result.delegates.map(delegate =>
-					node.expect(delegate.username).to.have.string(partialName));
+				node.expect(res.body.result[0].type).to.equal('address');
+				res.body.result.map(delegate =>
+					node.expect(delegate.description).to.have.string(partialName));
 				done();
 			});
 		});
 
-		it('using no input should fail', (done) => {
+		it('using no input should result empty array', (done) => {
 			getSearch('', (err, res) => {
-				node.expect(res.body).to.have.property('success').to.be.equal(false);
-				node.expect(res.body).to.have.property('error').to.be.a('string');
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body).to.have.property('result').to.be.lengthOf(0);
 				done();
 			});
 		});

--- a/test/api/common.js
+++ b/test/api/common.js
@@ -36,6 +36,10 @@ describe('Common API', () => {
 		node.get(`/api/search?id=${id}`, done);
 	};
 
+	const getUnifiedSearch = (id, done) => {
+		node.get(`/api/unifiedSearch?q=${id}`, done);
+	};
+
 	/* Define api endpoints to test */
 	describe('GET /api/version', () => {
 		it('should be ok', (done) => {
@@ -57,9 +61,77 @@ describe('Common API', () => {
 	});
 
 
+	// Original search, not used by the UI anymore
 	describe('GET /api/search', () => {
 		it('using known block should be ok', (done) => {
 			getSearch(params.blockId, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('block');
+				node.expect(res.body.result.id).to.equal(params.blockId);
+				done();
+			});
+		});
+
+		it('using known height should be ok', (done) => {
+			getSearch('1', (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('block');
+				node.expect(res.body.result.id).to.equal(params.blockId);
+				done();
+			});
+		});
+
+		it('using known address should be ok', (done) => {
+			getSearch(params.address, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('address');
+				node.expect(res.body.result.id).to.equal(params.address);
+				done();
+			});
+		});
+
+		it('using known transaction should be ok', (done) => {
+			getSearch(params.tx, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('tx');
+				node.expect(res.body.result.id).to.equal(params.tx);
+				done();
+			});
+		});
+
+		it('using known delegate should be ok', (done) => {
+			getSearch(params.username, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('delegate');
+				node.expect(res.body.result.delegates[0].address).to.equal(params.address);
+				done();
+			});
+		});
+
+		it('using partial known delegate should be ok', (done) => {
+			const partialName = 'gene';
+			getSearch(partialName, (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(true);
+				node.expect(res.body.result.type).to.equal('delegate');
+				res.body.result.delegates.map(delegate =>
+					node.expect(delegate.username).to.have.string(partialName));
+				done();
+			});
+		});
+
+		it('using no input should fail', (done) => {
+			getSearch('', (err, res) => {
+				node.expect(res.body).to.have.property('success').to.be.equal(false);
+				node.expect(res.body).to.have.property('error').to.be.a('string');
+				done();
+			});
+		});
+	});
+
+	// New search
+	describe('GET /api/unifiedSearch', () => {
+		it('using known block should be ok', (done) => {
+			getUnifiedSearch(params.blockId, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('block');
 				node.expect(res.body.result[0].id).to.equal(params.blockId);
@@ -68,7 +140,7 @@ describe('Common API', () => {
 		});
 
 		it('using known height should be ok', (done) => {
-			getSearch('1', (err, res) => {
+			getUnifiedSearch('1', (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('block');
 				node.expect(res.body.result[0].id).to.equal(params.blockId);
@@ -77,7 +149,7 @@ describe('Common API', () => {
 		});
 
 		it('using known address should be ok', (done) => {
-			getSearch(params.address, (err, res) => {
+			getUnifiedSearch(params.address, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('address');
 				node.expect(res.body.result[0].id).to.equal(params.address);
@@ -86,7 +158,7 @@ describe('Common API', () => {
 		});
 
 		it('using known transaction should be ok', (done) => {
-			getSearch(params.tx, (err, res) => {
+			getUnifiedSearch(params.tx, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('tx');
 				node.expect(res.body.result[0].id).to.equal(params.tx);
@@ -95,7 +167,7 @@ describe('Common API', () => {
 		});
 
 		it('using known delegate should be ok', (done) => {
-			getSearch(params.username, (err, res) => {
+			getUnifiedSearch(params.username, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('address');
 				node.expect(res.body.result[0].id).to.equal(params.address);
@@ -105,7 +177,7 @@ describe('Common API', () => {
 
 		it('using partial known delegate should be ok', (done) => {
 			const partialName = 'gene';
-			getSearch(partialName, (err, res) => {
+			getUnifiedSearch(partialName, (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body.result[0].type).to.equal('address');
 				res.body.result.map(delegate =>
@@ -115,7 +187,7 @@ describe('Common API', () => {
 		});
 
 		it('using no input should result empty array', (done) => {
-			getSearch('', (err, res) => {
+			getUnifiedSearch('', (err, res) => {
 				node.expect(res.body).to.have.property('success').to.be.equal(true);
 				node.expect(res.body).to.have.property('result').to.be.lengthOf(0);
 				done();


### PR DESCRIPTION
### What was the problem?

The search results didn't show all entries matching query based on the blockchain data source.

### How did I fix it?

- Normalized the response format.
- Added strict search and full-text search as two separate complementary methods producing one result.
- Updated the frontend code to support the new response format.
- Added proper transaction ID, block ID and block height handling.

### How to test it?

Try to search for `9` or `genesis` on testnet.

### Review checklist

* The PR solves #898
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
