### PR TITLE
SDK 2.0 support - Closes #911

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,9 @@ let serverStatus = status.NOT_RUNNING;
 const startServer = (cb) => {
 	getNodeConstants().then((result) => {
 		logger.info(`Connected to the node ${app.get('lisk address')}, Lisk Core version ${result.version}`);
-		app.set('constants', result);
+		Object.keys(result).forEach((item) => {
+			app.set(`node.${item}`, result[item]);
+		});
 		const server = app.listen(app.get('port'), app.get('host'), (err) => {
 			if (err) {
 				logger.info(err);

--- a/app.js
+++ b/app.js
@@ -210,7 +210,14 @@ const getNodeConstants = () => new Promise((success, error) => {
 		} else if (response.statusCode === 200) {
 			if (body && body.data) {
 				app.set('nodeConstants', body.data);
-				return success({ success: true, version: body.data.version });
+				return success({
+					version: body.data.version,
+					epoch: new Date(body.data.epoch) / 1000,
+					protocolVersion: body.data.protocolVersion,
+					nethash: body.data.nethash,
+					majorVersion: body.data.version.split('.')[0],
+					minorVersion: body.data.version.split('.')[1],
+				});
 			}
 		}
 		return error({ success: false, error: body.error });
@@ -224,6 +231,7 @@ let serverStatus = status.NOT_RUNNING;
 const startServer = (cb) => {
 	getNodeConstants().then((result) => {
 		logger.info(`Connected to the node ${app.get('lisk address')}, Lisk Core version ${result.version}`);
+		app.set('constants', result);
 		const server = app.listen(app.get('port'), app.get('host'), (err) => {
 			if (err) {
 				logger.info(err);

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -227,12 +227,8 @@ module.exports = function (app) {
 	};
 
 	this.getUnconfirmedTransactions = function (transactions, error, success) {
-		let unconfirmedUrl = '';
-		if (app.get('node.majorVersion') === '2') {
-			unconfirmedUrl = '/node/transactions/ready';
-		} else {
-			unconfirmedUrl = '/node/transactions/unconfirmed';
-		}
+		let unconfirmedUrl = '/node/transactions/unconfirmed';
+		if (app.get('node.majorVersion') === '2') unconfirmedUrl = '/node/transactions/ready';
 
 		async.waterfall([
 			cb => request.get({

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -227,9 +227,16 @@ module.exports = function (app) {
 	};
 
 	this.getUnconfirmedTransactions = function (transactions, error, success) {
+		let unconfirmedUrl = '';
+		if (app.get('node.majorVersion') === '2') {
+			unconfirmedUrl = '/node/transactions/ready';
+		} else {
+			unconfirmedUrl = '/node/transactions/unconfirmed';
+		}
+
 		async.waterfall([
 			cb => request.get({
-				url: `${app.get('lisk address')}/node/transactions/unconfirmed`,
+				url: `${app.get('lisk address')}${unconfirmedUrl}`,
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {

--- a/lib/api/transactions.js
+++ b/lib/api/transactions.js
@@ -236,7 +236,7 @@ module.exports = function (app) {
 				json: true,
 			}, (err, response, body) => {
 				if (err || response.statusCode !== 200) {
-					return error({ success: false, error: (err || 'Response was unsuccessful') });
+					return cb(null, transactions);
 				} else if (body && Array.isArray(body.data)) {
 					body.transactions = concatenate(transactions, body.data);
 					return cb(null, body.transactions);


### PR DESCRIPTION
### What was the problem?

Due to the API change, the unconfirmed transactions are not displayed on the landing page.

### How did I fix it?

The `getUnconfirmedTransactions` controller uses the SDK 2.0 API to get transactions in the state `ready`.

### How to test it?

Run the Explorer and open the landing page.

### Review checklist

* The PR solves #911
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
