### PR TITLE
Update to Core 3.0.0-alpha.1 API changes - Closes #931

### DIFF
--- a/docker/explorer/docker-compose.yml
+++ b/docker/explorer/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: lisk/explorer:latest
     depends_on:
       - explorer-cache
-      - freegeoip
     networks:
       - lisk-explorer
     restart: on-failure
@@ -13,7 +12,8 @@ services:
       - LISK_HOST=${EXPLORER_LISK_HOST}
       - LISK_PORT=${EXPLORER_LISK_PORT}
       - REDIS_HOST=explorer-cache
-      - FREEGEOIP_HOST=freegeoip
+      - FREEGEOIP_HOST=geoip.lisk.io
+      - FREEGEOIP_PORT=80
 
   explorer-cache:
     image: redis:alpine
@@ -30,12 +30,6 @@ services:
     environment:
       - REDIS_HOST=explorer-cache
     command: ./node_modules/grunt-cli/bin/grunt candles:build
-
-  freegeoip:
-    image: fiorix/freegeoip
-    networks:
-      - lisk-explorer
-    restart: on-failure
 
 
 networks:

--- a/docs/run_with_docker.md
+++ b/docs/run_with_docker.md
@@ -86,6 +86,7 @@ docker run -p 6040:6040 \
 	-e LISK_PORT=<LISK_NODE_PORT> \
 	-e REDIS_HOST=lisk-redis \
 	-e FREEGEOIP_HOST=geoip.lisk.io \
+	-e FREEGEOIP_PORT=80 \
 	--network=lisk-net \
 	--name=lisk-explorer \
 	-d lisk-explorer:1.4.3

--- a/docs/run_with_docker.md
+++ b/docs/run_with_docker.md
@@ -85,7 +85,7 @@ docker run -p 6040:6040 \
 	-e LISK_HOST=<LISK_NODE_IP> \
 	-e LISK_PORT=<LISK_NODE_PORT> \
 	-e REDIS_HOST=lisk-redis \
-	-e FREEGEOIP_HOST=lisk-freegeoip \
+	-e FREEGEOIP_HOST=geoip.lisk.io \
 	--network=lisk-net \
 	--name=lisk-explorer \
 	-d lisk-explorer:1.4.3

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -19,6 +19,15 @@ const async = require('async');
 const dns = require('dns');
 const logger = require('../../utils/logger');
 
+const mapLiskCoreV3StateFormat = (state) => {
+	const stateMapping = {
+		unknown: 0,
+		disconnected: 1,
+		connected: 2,
+	};
+	return stateMapping[state] !== undefined ? stateMapping[state] : state;
+};
+
 module.exports = function (app) {
 	const setOffsetAndLimit = (url, offset, limit) => {
 		if (!isNaN(offset)) {
@@ -317,7 +326,7 @@ module.exports = function (app) {
 			p.osBrand = osBrand(p.os);
 			this.ips.push(p.ip);
 
-			switch (parseInt(p.state, 10)) {
+			switch (parseInt(mapLiskCoreV3StateFormat(p.state), 10)) {
 			case 1:
 				p.humanState = 'Disconnected';
 				this.list.disconnected.push(p);
@@ -365,7 +374,7 @@ module.exports = function (app) {
 			ip: o.ip,
 			httpPort: o.httpPort || 'n/a',
 			wsPort: o.wsPort || 'n/a',
-			state: o.state,
+			state: mapLiskCoreV3StateFormat(o.state),
 			os: o.os,
 			version: o.version,
 			broadhash: o.broadhash,

--- a/utils/knownAddresses.js
+++ b/utils/knownAddresses.js
@@ -97,7 +97,7 @@ module.exports = function (app, config, client) {
 						logger.warn('KnownAddresses:', `Failed to get known addresses from ${config.knownAccountsUrl}, falling back to the local copy`);
 						knownNetworks = require('../knowledge/networks.json') || {};
 						// eslint-disable-next-line import/no-dynamic-require
-						knownAccounts = require(`../knowledge/known_${knownNetworks[nethash]}.json`) || {};
+						knownAccounts = knownNetworks[nethash] ? require(`../knowledge/known_${knownNetworks[nethash]}.json`) : {};
 					}
 
 					Object.keys(knownAccounts).forEach((address) => {


### PR DESCRIPTION
### What was the problem?
Changes described in #931 had to be made

### How did I fix it?
- [x] Map new peer.state values to old ones

Note that peers locations (flags and map) are currently missing because of freegeoip not being available anymore. This is not related to core 3.0 migration and will be solved separately.

### How to test it?

Follow steps to reproduce in #931

### Review checklist

* The PR resolves #931
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
