### PR TITLE
Nethash to network name translation - Closes #934

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,9 +63,9 @@ app.orders = new utils.orders(config, client);
 
 app.set('version', packageJson.version);
 app.set('strict routing', true);
-app.set('lisk address', `http://${config.lisk.host}:${config.lisk.port}${config.lisk.apiPath}`);
-app.set('lisk websocket address', `http://${config.lisk.host}:${config.lisk.port}`);
-app.set('freegeoip address', `http://${config.freegeoip.host}:${config.freegeoip.port}`);
+app.set('lisk address', config.lisk.http);
+app.set('lisk websocket address', config.lisk.ws);
+app.set('freegeoip address', config.freegeoip);
 app.set('exchange enabled', config.exchangeRates.enabled);
 app.set('uiMessage', config.uiMessage);
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -31,8 +31,8 @@ app.exchange = new utils.exchange(config);
 app.knownAddresses = new utils.knownAddresses();
 app.knownAddresses.load();
 
-app.set('lisk address', `http://${config.lisk.host}:${config.lisk.port}`);
-app.set('freegeoip address', `http://${config.freegeoip.host}:${config.freegeoip.port}`);
+app.set('lisk address', config.lisk.http);
+app.set('freegeoip address', config.freegeoip);
 
 const tests = new benchmarks(app, api);
 

--- a/config.js
+++ b/config.js
@@ -31,15 +31,13 @@ config.port = 6040; // Port to listen on
 /**
  * LISK node
  */
-config.lisk.host = process.env.LISK_HOST || '127.0.0.1';
-config.lisk.port = process.env.LISK_PORT || 4000;
-config.lisk.apiPath = '/api';
+config.lisk.http = process.env.LISK_URL_HTTP || 'http://127.0.0.1:4000/api';
+config.lisk.ws = process.env.LISK_URL_WS || 'ws://127.0.0.1:4000';
 
 /**
  * FreeGeoIP server
  */
-config.freegeoip.host = process.env.FREEGEOIP_HOST || '127.0.0.1';
-config.freegeoip.port = process.env.FREEGEOIP_PORT || 8080;
+config.freegeoip = process.env.FREEGEOIP_URL || 'https://geoip.lisk.io';
 
 /**
  * Redis server

--- a/docker/explorer/.env
+++ b/docker/explorer/.env
@@ -1,2 +1,2 @@
-EXPLORER_LISK_HOST=mainnet.lisk.io
-EXPLORER_LISK_PORT=8000
+EXPLORER_LISK_HTTP_URL=https://node.lisk.io/api
+EXPLORER_LISK_WS_URL=wss://node.lisk.io

--- a/docker/explorer/docker-compose.yml
+++ b/docker/explorer/docker-compose.yml
@@ -9,11 +9,10 @@ services:
       - lisk-explorer
     restart: on-failure
     environment:
-      - LISK_HOST=${EXPLORER_LISK_HOST}
-      - LISK_PORT=${EXPLORER_LISK_PORT}
+      - LISK_URL_HTTP=${EXPLORER_LISK_HTTP_URL}
+      - LISK_URL_WS=${EXPLORER_LISK_WS_URL}
       - REDIS_HOST=explorer-cache
-      - FREEGEOIP_HOST=geoip.lisk.io
-      - FREEGEOIP_PORT=80
+      - FREEGEOIP_URL=https://geoip.lisk.io
 
   explorer-cache:
     image: redis:alpine

--- a/docker/jenkins/.env
+++ b/docker/jenkins/.env
@@ -13,5 +13,5 @@ ENV_LISK_DB_USER=lisk
 # postgresql container for the first time.
 ENV_LISK_DB_PASSWORD=password
 
-EXPLORER_LISK_HOST=lisk
-EXPLORER_LISK_PORT=4000
+EXPLORER_LISK_HTTP_URL=http://lisk:4000/api
+EXPLORER_LISK_WS_URL=ws://lisk:4000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-explorer",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "npm": "6.1.0"
   },
   "scripts": {
-    "start": "npm run start:local",
-    "start:local": "LISK_HOST=localhost LISK_PORT=4000 node app.js",
-    "start:testnet": "LISK_HOST=testnet.lisk.io LISK_PORT=7000 node app.js",
-    "start:mainnet": "LISK_HOST=explorer.lisk.io LISK_PORT=8000 node app.js",
+    "start": "node app.js",
+    "start:local": "LISK_URL_HTTP='http://localhost:4000/api' LISK_URL_WS='ws://localhost:4000' node app.js",
+    "start:testnet": "LISK_URL_HTTP='https://testnet.lisk.io/api' LISK_URL_WS='wss://testnet.lisk.io' node app.js",
+    "start:mainnet": "LISK_URL_HTTP='https://node.lisk.io/api' LISK_URL_WS='wss://node.lisk.io' node app.js",
     "test": "./node_modules/.bin/grunt test --verbose",
     "test:e2e": "protractor protractor.conf.js",
     "test-live": "npm test -- --auto-watch --no-single-run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-explorer",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "description": "Lisk blockchain explorer",
   "keywords": [
     "lisk",

--- a/src/filters/net-hash.js
+++ b/src/filters/net-hash.js
@@ -24,7 +24,7 @@ AppFilters.filter('nethash', () => (nethash) => {
 		return 'Testnet';
 	case 'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511':
 		return 'Mainnet';
-	case 'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c':
+	case '3b0f31679a60be540fa96094355ccb556459f2df8b34a542db3795ebb5f0e521':
 		return 'Betanet';
 	default:
 		return 'local';


### PR DESCRIPTION
### What was the problem?

The betanet nethash to network name translation was missing.

### How did I fix it?

- Added the network name with a proper nethash
- Added support for HTTPS/WSS

### How to test it?

`npm test`

### Review checklist

* The PR solves #934
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
